### PR TITLE
scaleColumns refactor

### DIFF
--- a/pyoptsparse/pyOpt_utils.py
+++ b/pyoptsparse/pyOpt_utils.py
@@ -396,11 +396,11 @@ def scaleColumns(mat, factor):
         raise Error("scaleColumns only works for CSR pyoptsparse matrix format")
     if mat['shape'][1] != len(factor):
         raise Error("Length of factor is incorrect")
+    # print('SCALE COLUMNS')
     for i in range(mat['shape'][0]):
         iStart = mat['csr'][IROWP][i]
         iEnd = mat['csr'][IROWP][i+1]
-        for j in range(iStart, iEnd):
-            mat['csr'][IDATA][j] *= factor[mat['csr'][ICOLIND][j]]
+        mat['csr'][IDATA][iStart:iEnd] *= factor[mat['csr'][ICOLIND][iStart:iEnd]]
 
 def scaleRows(mat, factor):
     """

--- a/pyoptsparse/pyOpt_utils.py
+++ b/pyoptsparse/pyOpt_utils.py
@@ -396,7 +396,6 @@ def scaleColumns(mat, factor):
         raise Error("scaleColumns only works for CSR pyoptsparse matrix format")
     if mat['shape'][1] != len(factor):
         raise Error("Length of factor is incorrect")
-    # print('SCALE COLUMNS')
     for i in range(mat['shape'][0]):
         iStart = mat['csr'][IROWP][i]
         iEnd = mat['csr'][IROWP][i+1]


### PR DESCRIPTION
Vectorized the inner loop of pyOpt_utils.scaleColumns for improved performance.

    for i in range(mat['shape'][0]):
        iStart = mat['csr'][IROWP][i]
        iEnd = mat['csr'][IROWP][i+1]
        for j in range(iStart, iEnd):
            mat['csr'][IDATA][j] *= factor[mat['csr'][ICOLIND][j]]

Becomes 

    for i in range(mat['shape'][0]):
        iStart = mat['csr'][IROWP][i]
        iEnd = mat['csr'][IROWP][i+1]
        mat['csr'][IDATA][iStart:iEnd] *= factor[mat['csr'][ICOLIND][iStart:iEnd]]

On a optimal control demonstration problem via OpenMDAO this saved about 25 seconds of a total 70 seconds of execution time.
