### PR TITLE
modify setup.py for building windows platform wheels using intel fort…

### DIFF
--- a/pyoptsparse/pyFSQP/setup.py
+++ b/pyoptsparse/pyFSQP/setup.py
@@ -4,16 +4,16 @@ import os,sys
 
 
 def configuration(parent_package='',top_path=None):
-    
+
     from numpy.distutils.misc_util import Configuration
-    
+
     config = Configuration('pyFSQP',parent_package,top_path)
-    
+    """
     config.add_library('ffsqp',
         sources=[os.path.join('source', '*.f')])
     config.add_extension('ffsqp',
         sources=['source/f2py/ffsqp.pyf'],
         libraries=['ffsqp'])
     config.add_data_files('LICENSE','README')
-    
+    """
     return config

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import os,sys
 # Check if we have numpy:
 try:
     from numpy.distutils.misc_util import Configuration
+    from setuptools import setup
     from numpy.distutils.core import setup
 except:
     raise ImportError('pyOptSparse requires numpy version 1.0 or later')
@@ -20,7 +21,7 @@ if len(sys.argv) == 1:
     sys.exit(-1)
 
 def configuration(parent_package='',top_path=None):
-    config = Configuration(None,parent_package,top_path)
+    config = Configuration('pyoptsparse',parent_package,top_path)
     config.set_options(ignore_setup_xxx_py=True,
                        assume_default_configuration=True,
                        delegate_options_to_subpackages=True,
@@ -31,7 +32,7 @@ def configuration(parent_package='',top_path=None):
 if __name__ == '__main__':
 
     setup(
-        name             = 'pyoptsparse',
+        name             = '',
         version          = '1.0.0',
         author           = 'Dr. Gaetan Kenway',
         author_email     = 'gaetank@gmail.com',
@@ -58,4 +59,4 @@ if __name__ == '__main__':
                             'Topic :: Education'],
         configuration = configuration,
     )
-    
+


### PR DESCRIPTION
…ran and visual studio 2015 on python 3.6, disable pyFSQP to get past linker error

Per Justin Gray's request, here is the modifications required to build a platform wheel on windows using the Intel Fortran compiler (for building SNOPT).  I'm not sure if these modifications will break the linux builds.  Perhaps we might want to create a separate setup.windows.py?  If so, reject the pull request and I can go that route.