### PR TITLE
Major iteration counting

### DIFF
--- a/postprocessing/OptView.py
+++ b/postprocessing/OptView.py
@@ -223,11 +223,8 @@ class Display(object):
                     pass
 
                 # Check to see if there is proper saved info about iter type
-                if 'iu0' in db['0'].keys():
-                    if db[db['last']]['iu0'] > 0:
-                        self.storedIters = True
-                    else:
-                        self.storedIters = False
+                if 'isMajor' in db['0'].keys():
+                    self.storedIters = True
                 else:
                     self.storedIters = False
 
@@ -271,11 +268,10 @@ class Display(object):
                 # actual major iteration. In particular, one has funcs
                 # and the next has funcsSens, but they're both part of the
                 # same major iteration.
-                if any('funcs' == s for s in db[key].keys()):
-
+                if 'funcs' in db[key].keys():
                     # If this iteration has 'funcs' within it, but it's not
                     # flagged as major, then it's a minor iteration.
-                    if i == 0:
+                    if i == 0 or db[key]['isMajor']:
                         self.iter_type[i] = 1
                     else:
                         self.iter_type[i] = 2
@@ -294,27 +290,6 @@ class Display(object):
                 else:
                     self.iter_type[i] = 0 # this is not a real iteration,
                                           # just the sensitivity evaluation
-
-            min_list = []
-            # Loop over each optimization iteration
-            for i, iter_type in enumerate(self.iter_type):
-
-                if iter_type == 0:
-                    continue
-
-                key = '%d' % i
-
-                # # If the proper history is stored coming out of
-                # # pyoptsparse, use that for filtering major iterations.
-                # if self.storedIters:
-                #     if db[key]['iu0'] != db[prev_key]['iu0']:
-                #         min_array = np.array(min_list)
-                #         argmin = np.argmin(min_array[:, 1])
-                #         major_key = min_array[argmin, 0]
-                #         self.iter_type[int(major_key)] = 1
-                #         min_list = []
-                #     min_list.append([int(key), db[key]['funcs'][self.obj_key]])
-                #     prev_key = i
 
         else: # this is if it's OpenMDAO
             for i, iter_type in enumerate(self.iter_type):

--- a/pyoptsparse/pyOpt_history.py
+++ b/pyoptsparse/pyOpt_history.py
@@ -43,7 +43,7 @@ class History(object):
        closed
 
     flag : str
-        String speciying the mode. Similar to what was used in
+        String specifying the mode. Similar to what was used in
         shelve. 'n' for a new database and 'r' to read an existing one. 
        """
     def __init__(self, fileName, temp=False, flag='n'):
@@ -137,11 +137,23 @@ class History(object):
         callCounter = None
         for i in range(last,0,-1):
             key = '%d'% i
-            if np.isclose(x,self.db[key]['xuser']['xvars']).all() and 'funcs' in self.db[key].keys():
+            xuser = self.deProcessX(self.db[key]['xuser'])
+            if np.isclose(x,xuser).all() and 'funcs' in self.db[key].keys():
                 callCounter = i
                 break
         return callCounter
 
+    def deProcessX(self,xuser):
+        """
+        This is a much more simple version of pyOpt_history.deProcessX without error checking.
+        We traverse the OrderedDict and stack all the DVs as a single numpy array, preserving 
+        the order so that we get the correct x vector.
+        """
+        x_list = []
+        for key in xuser.keys():
+            x_list.append(xuser[key])
+        x_array = np.hstack(x_list)
+        return x_array
 
     def __del__(self):
         try:

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -88,7 +88,8 @@ class Optimizer(object):
 
         # Create object to pass information about major iterations.
         # Only relevant for SNOPT.
-        self.iu0 = 0
+        self.isMajor = False
+        self.iterDict = {}
 
         # Store the jacobian conversion maps
         self._jac_map_csr_to_csc = None
@@ -511,7 +512,7 @@ class Optimizer(object):
         hist['fail'] = masterFail
 
         # Save information about major iteration counting (only matters for SNOPT).
-        hist['iu0'] = self.iu0
+        hist['isMajor'] = False # this will be updated in _snstop if it is major
 
         # Add constraint and variable bounds at beginning of optimization.
         # This info is used for visualization using OptView.

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -27,6 +27,7 @@ from .pyOpt_solution import Solution
 from .pyOpt_optimization import INFINITY
 from .pyOpt_utils import convertToDense, convertToCOO, extractRows, \
     mapToCSC, scaleRows, IDATA
+from collections import OrderedDict
 eps = numpy.finfo(1.0).eps
 
 # =============================================================================
@@ -517,8 +518,8 @@ class Optimizer(object):
         # Add constraint and variable bounds at beginning of optimization.
         # This info is used for visualization using OptView.
         if self.callCounter == 0 and self.optProb.comm.rank == 0:
-            conInfo = {}
-            varInfo = {}
+            conInfo = OrderedDict()
+            varInfo = OrderedDict()
 
             # Cycle through constraints adding the bounds
             for key in self.optProb.constraints.keys():

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -314,9 +314,7 @@ class SNOPT(Optimizer):
 
         # Store the starting time if the keyword timeLimit is given:
         self.timeLimit = timeLimit
-        self.startTime = None
-        if self.timeLimit is not None:
-            self.startTime = time.time()
+        self.startTime = time.time()
 
         if len(optProb.constraints) == 0:
             # If the user *actually* has an unconstrained problem,
@@ -493,8 +491,8 @@ class SNOPT(Optimizer):
 
             # The snopt c interface
             timeA = time.time()
-            snopt.snoptc(start, nnCon, nnObj, nnJac, iObj, ObjAdd, ProbNm,
-                         self._userfg_wrap, Acol, indA, locA, bl, bu,
+            snopt.snkerc(start, nnCon, nnObj, nnJac, iObj, ObjAdd, ProbNm,
+                         self._userfg_wrap, snopt.snlog, snopt.snlog2, snopt.sqlog, self._snstop, Acol, indA, locA, bl, bu,
                          Names, hs, xs, pi, rc, inform, mincw, miniw, minrw,
                          nS, ninf, sinf, ff, cu, iu, ru, cw, iw, rw)
             optTime = time.time()-timeA
@@ -546,7 +544,7 @@ class SNOPT(Optimizer):
         which will take care of everything else.
         """
         fail = False
-        self.iu0 = iu[0]
+        self.isMajor = False
         if mode == 0 or mode == 2:
             fobj, fcon, fail = self._masterFunc(x, ['fobj', 'fcon'])
         if not fail:
@@ -572,6 +570,38 @@ class SNOPT(Optimizer):
                 mode = -2 # User requested termination
 
         return mode, fobj, gobj, fcon, gcon
+
+    def _snstop(self,ktcond,mjrprtlvl,minimize,n,nncon,nnobj,ns,itn,nmajor,nminor,nswap,condzhz,iobj,scaleobj,objadd,fobj,fmerit,penparm,step,primalinf,dualinf,maxvi,maxvirel,hs,locj,indj,jcol,scales,bl,bu,fx,fcon,gcon,gobj,ycon,pi,rc,rg,x,cu,iu,ru,cw,iw,rw):
+        """
+        This routine is called every major iteration in SNOPT, after solving QP but before line search
+        Currently we use it just to determine the correct major iteration counting,
+        and save some parameters in history if needed
+
+        returning with iabort != 0 will terminate SNOPT immediately
+        """
+        self.isMajor = True
+        iterDict = {
+            'isMajor' : True,
+            'time' : time.time() - self.startTime,
+            'nMajor' : nmajor,
+            'nMinor' : nminor,
+            'merit' : fmerit,
+            'feasibility' : primalinf,
+            'optimality'  : dualinf,
+            'penalty' : penparm[2],
+            'pi' : pi,
+        }
+        if self.storeHistory:
+            currX = x[:n] # only the first n component is x, the rest are the slacks
+            if nmajor == 0:
+                callCounter = 0
+            else:
+                callCounter = self.hist.getCallCounter(currX)
+            if callCounter is not None:
+                self.hist.write(callCounter, iterDict)
+        iabort = 0
+        return iabort
+
 
     def _set_snopt_options(self, iPrint, iSumm, cw, iw, rw):
         """

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -593,6 +593,14 @@ class SNOPT(Optimizer):
         H = numpy.matmul(Umat.T,Umat)
         return H
 
+    def _getPenaltyParam(self,iw,rw):
+        """
+        Retrieves the full penalty parameter vector from the work arrays.
+        """
+        nnCon = iw[23-1]
+        lxPen = iw[304-1]-1
+        xPen = rw[lxPen:lxPen+nnCon]
+        return xPen
 
     def _snstop(self,ktcond,mjrprtlvl,minimize,n,nncon,nnobj,ns,itn,nmajor,nminor,nswap,condzhz,iobj,scaleobj,objadd,fobj,fmerit,penparm,step,primalinf,dualinf,maxvi,maxvirel,hs,locj,indj,jcol,scales,bl,bu,fx,fcon,gcon,gobj,ycon,pi,rc,rg,x,cu,iu,ru,cw,iw,rw):
         """
@@ -604,6 +612,7 @@ class SNOPT(Optimizer):
         """
         self.isMajor = True
         H = self._getHessian(iw,rw)
+        xPen = self._getPenaltyParam(iw,rw)
         iterDict = {
             'isMajor' : True,
             'time' : time.time() - self.startTime,
@@ -612,7 +621,7 @@ class SNOPT(Optimizer):
             'merit' : fmerit,
             'feasibility' : primalinf,
             'optimality'  : dualinf,
-            'penalty' : penparm[2],
+            'penalty' : xPen,
             'pi' : pi,
             'Hessian' : H,
         }

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -603,6 +603,7 @@ class SNOPT(Optimizer):
         returning with iabort != 0 will terminate SNOPT immediately
         """
         self.isMajor = True
+        H = self._getHessian(iw,rw)
         iterDict = {
             'isMajor' : True,
             'time' : time.time() - self.startTime,
@@ -613,13 +614,15 @@ class SNOPT(Optimizer):
             'optimality'  : dualinf,
             'penalty' : penparm[2],
             'pi' : pi,
+            'Hessian' : H,
         }
         if self.storeHistory:
             currX = x[:n] # only the first n component is x, the rest are the slacks
             if nmajor == 0:
                 callCounter = 0
             else:
-                callCounter = self.hist.getCallCounter(currX)
+                xScaled = self.optProb.invXScale * currX + self.optProb.xOffset
+                callCounter = self.hist.getCallCounter(xScaled)
             if callCounter is not None:
                 self.hist.write(callCounter, iterDict)
         iabort = 0

--- a/pyoptsparse/pySNOPT/source/f2py/snopt.pyf
+++ b/pyoptsparse/pySNOPT/source/f2py/snopt.pyf
@@ -28,7 +28,197 @@ python module snoptc__user__routines
                 integer intent(in) :: leniu
                 double precision intent(in) :: ru(lenru)
                 integer intent(in) :: lenru
-	    end subroutine userfg
+        end subroutine userfg
+        subroutine snstop(iabort,ktcond,mjrprtlvl,minimize,m,maxs,n,nb,nncon0,nncon,nnobj0,nnobj,ns,itn,nmajor,nminor,nswap,condzhz,iobj,scaleobj,objadd,fobj,fmerit,penparm,step,primalinf,dualinf,maxvi,maxvirel,hs,nej,nlocj,locj,indj,jcol,negcon,scales,bl,bu,fx,fcon,gcon,gobj,ycon,pi,rc,rg,x,cu,lencu,iu,leniu,ru,lenru,cw,lencw,iw,leniw,rw,lenrw) ! in test.f
+            integer, intent(out) :: iabort
+            logical dimension(2) :: ktcond
+            integer :: mjrprtlvl
+            integer :: minimize
+            integer, optional,check(len(pi)>=m),depend(pi) :: m=len(pi)
+            integer, optional,check(len(rg)>=maxs),depend(rg) :: maxs=len(rg)
+            integer :: n
+            integer, optional,check(len(hs)>=nb),depend(hs) :: nb=len(hs)
+            integer, optional,check(len(fx)>=nncon0),depend(fx) :: nncon0=len(fx)
+            integer :: nncon
+            integer, optional,check(len(gobj)>=nnobj0),depend(gobj) :: nnobj0=len(gobj)
+            integer :: nnobj
+            integer :: ns
+            integer :: itn
+            integer :: nmajor
+            integer :: nminor
+            integer :: nswap
+            double precision :: condzhz
+            integer :: iobj
+            double precision :: scaleobj
+            double precision :: objadd
+            double precision :: fobj
+            double precision :: fmerit
+            double precision dimension(4) :: penparm
+            double precision :: step
+            double precision :: primalinf
+            double precision :: dualinf
+            double precision :: maxvi
+            double precision :: maxvirel
+            integer dimension(nb) :: hs
+            integer, optional,check(len(indj)>=nej),depend(indj) :: nej=len(indj)
+            integer, optional,check(len(locj)>=nlocj),depend(locj) :: nlocj=len(locj)
+            integer dimension(nlocj) :: locj
+            integer dimension(nej) :: indj
+            double precision dimension(nej),depend(nej) :: jcol
+            integer, optional,check(len(gcon)>=negcon),depend(gcon) :: negcon=len(gcon)
+            double precision dimension(nb),depend(nb) :: scales
+            double precision dimension(nb),depend(nb) :: bl
+            double precision dimension(nb),depend(nb) :: bu
+            double precision dimension(nncon0) :: fx
+            double precision dimension(nncon0),depend(nncon0) :: fcon
+            double precision dimension(negcon) :: gcon
+            double precision dimension(nnobj0) :: gobj
+            double precision dimension(nncon0),depend(nncon0) :: ycon
+            double precision dimension(m) :: pi
+            double precision dimension(nb),depend(nb) :: rc
+            double precision dimension(maxs) :: rg
+            double precision dimension(nb),depend(nb) :: x
+            character dimension(lencu,8) :: cu
+            integer, optional,check(shape(cu,0)==lencu),depend(cu) :: lencu=shape(cu,0)
+            integer dimension(leniu) :: iu
+            integer, optional,check(len(iu)>=leniu),depend(iu) :: leniu=len(iu)
+            double precision dimension(lenru) :: ru
+            integer, optional,check(len(ru)>=lenru),depend(ru) :: lenru=len(ru)
+            character dimension(lencw,8) :: cw
+            integer, optional,check(shape(cw,0)==lencw),depend(cw) :: lencw=shape(cw,0)
+            integer dimension(leniw) :: iw
+            integer, optional,check(len(iw)>=leniw),depend(iw) :: leniw=len(iw)
+            double precision dimension(lenrw) :: rw
+            integer, optional,check(len(rw)>=lenrw),depend(rw) :: lenrw=len(rw)
+        end subroutine snstop
+        subroutine snlog(iabort,ktcond,mjrprtlvl,minimize,n,nb,nncon0,nnobj,ns,itn,nmajor,nminor,nswap,condzhz,iobj,scaleobj,objadd,fobj,fmerit,penparm,step,primalinf,dualinf,maxvi,maxvirel,hs,nej,nlocj,locj,indj,jcol,scales,bl,bu,fx,fcon,ycon,x,cu,lencu,iu,leniu,ru,lenru,cw,lencw,iw,leniw,rw,lenrw) ! in test.f
+            integer :: iabort
+            logical dimension(2) :: ktcond
+            integer :: mjrprtlvl
+            integer :: minimize
+            integer :: n
+            integer, optional,check(len(hs)>=nb),depend(hs) :: nb=len(hs)
+            integer, optional,check(len(fx)>=nncon0),depend(fx) :: nncon0=len(fx)
+            integer :: nnobj
+            integer :: ns
+            integer :: itn
+            integer :: nmajor
+            integer :: nminor
+            integer :: nswap
+            double precision :: condzhz
+            integer :: iobj
+            double precision :: scaleobj
+            double precision :: objadd
+            double precision :: fobj
+            double precision :: fmerit
+            double precision dimension(4) :: penparm
+            double precision :: step
+            double precision :: primalinf
+            double precision :: dualinf
+            double precision :: maxvi
+            double precision :: maxvirel
+            integer dimension(nb) :: hs
+            integer, optional,check(len(indj)>=nej),depend(indj) :: nej=len(indj)
+            integer, optional,check(len(locj)>=nlocj),depend(locj) :: nlocj=len(locj)
+            integer dimension(nlocj) :: locj
+            integer dimension(nej) :: indj
+            double precision dimension(nej),depend(nej) :: jcol
+            double precision dimension(nb),depend(nb) :: scales
+            double precision dimension(nb),depend(nb) :: bl
+            double precision dimension(nb),depend(nb) :: bu
+            double precision dimension(nncon0) :: fx
+            double precision dimension(nncon0),depend(nncon0) :: fcon
+            double precision dimension(nncon0),depend(nncon0) :: ycon
+            double precision dimension(nb),depend(nb) :: x
+            character dimension(lencu,8) :: cu
+            integer, optional,check(shape(cu,0)==lencu),depend(cu) :: lencu=shape(cu,0)
+            integer dimension(leniu) :: iu
+            integer, optional,check(len(iu)>=leniu),depend(iu) :: leniu=len(iu)
+            double precision dimension(lenru) :: ru
+            integer, optional,check(len(ru)>=lenru),depend(ru) :: lenru=len(ru)
+            character dimension(lencw,8) :: cw
+            integer, optional,check(shape(cw,0)==lencw),depend(cw) :: lencw=shape(cw,0)
+            integer dimension(leniw) :: iw
+            integer, optional,check(len(iw)>=leniw),depend(iw) :: leniw=len(iw)
+            double precision dimension(lenrw) :: rw
+            integer, optional,check(len(rw)>=lenrw),depend(rw) :: lenrw=len(rw)
+        end subroutine snlog
+        subroutine snlog2(probtype,probtag,elastic,gotr,firstfeas,feasible,justphase1,m,mbs,nnh,ns,jsq,jbr,jsr,linesp,liness,itn,itqp,kprc,lvlobje,pivot,step,ninf,sinf,ninfe,sinfe,wtinf,nonopt,objprt,condzhz,djqprt,rgnorm,kbs,xbs,iw,leniw) ! in test.f
+            integer :: probtype
+            character*20 :: probtag
+            logical :: elastic
+            logical :: gotr
+            logical :: firstfeas
+            logical :: feasible
+            logical :: justphase1
+            integer :: m
+            integer, optional,check(len(kbs)>=mbs),depend(kbs) :: mbs=len(kbs)
+            integer :: nnh
+            integer :: ns
+            integer :: jsq
+            integer :: jbr
+            integer :: jsr
+            integer :: linesp
+            integer :: liness
+            integer :: itn
+            integer :: itqp
+            integer :: kprc
+            integer :: lvlobje
+            double precision :: pivot
+            double precision :: step
+            integer :: ninf
+            double precision :: sinf
+            integer :: ninfe
+            double precision :: sinfe
+            double precision :: wtinf
+            integer :: nonopt
+            double precision :: objprt
+            double precision :: condzhz
+            double precision :: djqprt
+            double precision :: rgnorm
+            integer dimension(mbs) :: kbs
+            double precision dimension(mbs),depend(mbs) :: xbs
+            integer dimension(leniw) :: iw
+            integer, optional,check(len(iw)>=leniw),depend(iw) :: leniw=len(iw)
+        end subroutine snlog2
+        subroutine sqlog(probtype,probtag,elastic,gotr,firstfeas,feasible,justphase1,m,mbs,nnh,ns,jsq,jbr,jsr,linesp,liness,itn,itqp,kprc,lvlobje,pivot,step,ninf,sinf,ninfe,sinfe,wtinf,nonopt,objprt,condzhz,djqprt,rgnorm,kbs,xbs,iw,leniw) ! in test.f
+            integer :: probtype
+            character*20 :: probtag
+            logical :: elastic
+            logical :: gotr
+            logical :: firstfeas
+            logical :: feasible
+            logical :: justphase1
+            integer :: m
+            integer, optional,check(len(kbs)>=mbs),depend(kbs) :: mbs=len(kbs)
+            integer :: nnh
+            integer :: ns
+            integer :: jsq
+            integer :: jbr
+            integer :: jsr
+            integer :: linesp
+            integer :: liness
+            integer :: itn
+            integer :: itqp
+            integer :: kprc
+            integer :: lvlobje
+            double precision :: pivot
+            double precision :: step
+            integer :: ninf
+            double precision :: sinf
+            integer :: ninfe
+            double precision :: sinfe
+            double precision :: wtinf
+            integer :: nonopt
+            double precision :: objprt
+            double precision :: condzhz
+            double precision :: djqprt
+            double precision :: rgnorm
+            integer dimension(mbs) :: kbs
+            double precision dimension(mbs),depend(mbs) :: xbs
+            integer dimension(leniw) :: iw
+            integer, optional,check(len(iw)>=leniw),depend(iw) :: leniw=len(iw)
+        end subroutine sqlog
     end interface snoptc_user_interface
 end python module snoptc__user__routines
 python module snopt ! in 
@@ -203,6 +393,179 @@ python module snopt ! in
             double precision dimension(lenrw) :: rw
             integer optional,check(len(rw)>=lenrw),depend(rw) :: lenrw=len(rw)
         end subroutine snoptc
+        subroutine snkerc(start,m,n,ne,nname,nncon,nnobj,nnjac,iobj,objadd,prob,userfg,snlog,snlog2,sqlog,snstop,jcol,indj,locj,bl,bu,names,hs,x,pi,rc,inform,mincw,miniw,minrw,ns,ninf,sinf,obj,cu,lencu,iu,leniu,ru,lenru,cw,lencw,iw,leniw,rw,lenrw) ! in :snopt:snoptc.f
+            use snoptc__user__routines
+            character*(*) intent(inout) :: start
+            integer optional,check(len(pi)>=m),depend(pi) :: m=len(pi)
+            integer optional,check((len(locj)-1)>=n),depend(locj) :: n=(len(locj)-1)
+            integer optional,check(len(jcol)>=ne),depend(jcol) :: ne=len(jcol)
+            integer :: nncon 
+            integer :: nnobj
+            integer :: nnjac
+            integer :: iobj
+            double precision :: objadd
+            character*8 :: prob
+            external userfg,snlog,snlog2,sqlog,snstop
+            double precision dimension(ne) :: jcol
+            integer intent(inout), dimension(ne),depend(ne) :: indj
+            integer intent(inout), dimension(n + 1) :: locj
+            double precision intent(inout), dimension(n+m),depend(m,n) :: bl
+            double precision intent(inout), dimension(n+m),depend(m,n) :: bu
+            character*8 intent(in), dimension(nname) :: names
+            integer optional,check(len(names)==nname),depend(names) :: nname=len(names)
+            integer intent(inout), dimension(n+m),depend(m,n) :: hs
+            double precision intent(inout), dimension(n+m),depend(m,n) :: x
+            double precision intent(inout), dimension(m) :: pi
+            double precision intent(inout), dimension(n+m),depend(m,n) :: rc 
+            integer intent(inout) :: inform
+            integer intent(inout) :: mincw
+            integer intent(inout) :: miniw
+            integer intent(inout) :: minrw
+            integer :: ns
+            integer :: ninf
+            double precision :: sinf
+            double precision intent(inout) :: obj
+            character*8 intent(in,out), dimension(lencu) :: cu
+            integer optional,check(len(cu)==lencu),depend(cu) :: lencu=len(cu)
+            integer dimension(leniu) :: iu
+            integer optional,check(len(iu)>=leniu),depend(iu) :: leniu=len(iu)
+            double precision dimension(lenru) :: ru
+            integer optional,check(len(ru)>=lenru),depend(ru) :: lenru=len(ru)
+            character*8 intent(in,out), dimension(lencw) :: cw
+            integer optional,check(len(cw)==lencw),depend(cw) :: lencw=len(cw)
+            integer intent(inout), dimension(leniw) :: iw
+            integer optional,check(len(iw)>=leniw),depend(iw) :: leniw=len(iw)
+            double precision dimension(lenrw) :: rw
+            integer optional,check(len(rw)>=lenrw),depend(rw) :: lenrw=len(rw)
+        end subroutine snkerc
+        subroutine snlog(iabort,ktcond,mjrprtlvl,minimize,n,nb,nncon0,nnobj,ns,itn,nmajor,nminor,nswap,condzhz,iobj,scaleobj,objadd,fobj,fmerit,penparm,step,primalinf,dualinf,maxvi,maxvirel,hs,nej,nlocj,locj,indj,jcol,scales,bl,bu,fx,fcon,ycon,x,cu,lencu,iu,leniu,ru,lenru,cw,lencw,iw,leniw,rw,lenrw) ! in test.f
+            integer :: iabort
+            logical dimension(2) :: ktcond
+            integer :: mjrprtlvl
+            integer :: minimize
+            integer :: n
+            integer, optional,check(len(hs)>=nb),depend(hs) :: nb=len(hs)
+            integer, optional,check(len(fx)>=nncon0),depend(fx) :: nncon0=len(fx)
+            integer :: nnobj
+            integer :: ns
+            integer :: itn
+            integer :: nmajor
+            integer :: nminor
+            integer :: nswap
+            double precision :: condzhz
+            integer :: iobj
+            double precision :: scaleobj
+            double precision :: objadd
+            double precision :: fobj
+            double precision :: fmerit
+            double precision dimension(4) :: penparm
+            double precision :: step
+            double precision :: primalinf
+            double precision :: dualinf
+            double precision :: maxvi
+            double precision :: maxvirel
+            integer dimension(nb) :: hs
+            integer, optional,check(len(indj)>=nej),depend(indj) :: nej=len(indj)
+            integer, optional,check(len(locj)>=nlocj),depend(locj) :: nlocj=len(locj)
+            integer dimension(nlocj) :: locj
+            integer dimension(nej) :: indj
+            double precision dimension(nej),depend(nej) :: jcol
+            double precision dimension(nb),depend(nb) :: scales
+            double precision dimension(nb),depend(nb) :: bl
+            double precision dimension(nb),depend(nb) :: bu
+            double precision dimension(nncon0) :: fx
+            double precision dimension(nncon0),depend(nncon0) :: fcon
+            double precision dimension(nncon0),depend(nncon0) :: ycon
+            double precision dimension(nb),depend(nb) :: x
+            character dimension(lencu,8) :: cu
+            integer, optional,check(shape(cu,0)==lencu),depend(cu) :: lencu=shape(cu,0)
+            integer dimension(leniu) :: iu
+            integer, optional,check(len(iu)>=leniu),depend(iu) :: leniu=len(iu)
+            double precision dimension(lenru) :: ru
+            integer, optional,check(len(ru)>=lenru),depend(ru) :: lenru=len(ru)
+            character dimension(lencw,8) :: cw
+            integer, optional,check(shape(cw,0)==lencw),depend(cw) :: lencw=shape(cw,0)
+            integer dimension(leniw) :: iw
+            integer, optional,check(len(iw)>=leniw),depend(iw) :: leniw=len(iw)
+            double precision dimension(lenrw) :: rw
+            integer, optional,check(len(rw)>=lenrw),depend(rw) :: lenrw=len(rw)
+        end subroutine snlog
+        subroutine snlog2(probtype,probtag,elastic,gotr,firstfeas,feasible,justphase1,m,mbs,nnh,ns,jsq,jbr,jsr,linesp,liness,itn,itqp,kprc,lvlobje,pivot,step,ninf,sinf,ninfe,sinfe,wtinf,nonopt,objprt,condzhz,djqprt,rgnorm,kbs,xbs,iw,leniw) ! in test.f
+            integer :: probtype
+            character*20 :: probtag
+            logical :: elastic
+            logical :: gotr
+            logical :: firstfeas
+            logical :: feasible
+            logical :: justphase1
+            integer :: m
+            integer, optional,check(len(kbs)>=mbs),depend(kbs) :: mbs=len(kbs)
+            integer :: nnh
+            integer :: ns
+            integer :: jsq
+            integer :: jbr
+            integer :: jsr
+            integer :: linesp
+            integer :: liness
+            integer :: itn
+            integer :: itqp
+            integer :: kprc
+            integer :: lvlobje
+            double precision :: pivot
+            double precision :: step
+            integer :: ninf
+            double precision :: sinf
+            integer :: ninfe
+            double precision :: sinfe
+            double precision :: wtinf
+            integer :: nonopt
+            double precision :: objprt
+            double precision :: condzhz
+            double precision :: djqprt
+            double precision :: rgnorm
+            integer dimension(mbs) :: kbs
+            double precision dimension(mbs),depend(mbs) :: xbs
+            integer dimension(leniw) :: iw
+            integer, optional,check(len(iw)>=leniw),depend(iw) :: leniw=len(iw)
+        end subroutine snlog2
+        subroutine sqlog(probtype,probtag,elastic,gotr,firstfeas,feasible,justphase1,m,mbs,nnh,ns,jsq,jbr,jsr,linesp,liness,itn,itqp,kprc,lvlobje,pivot,step,ninf,sinf,ninfe,sinfe,wtinf,nonopt,objprt,condzhz,djqprt,rgnorm,kbs,xbs,iw,leniw) ! in test.f
+            integer :: probtype
+            character*20 :: probtag
+            logical :: elastic
+            logical :: gotr
+            logical :: firstfeas
+            logical :: feasible
+            logical :: justphase1
+            integer :: m
+            integer, optional,check(len(kbs)>=mbs),depend(kbs) :: mbs=len(kbs)
+            integer :: nnh
+            integer :: ns
+            integer :: jsq
+            integer :: jbr
+            integer :: jsr
+            integer :: linesp
+            integer :: liness
+            integer :: itn
+            integer :: itqp
+            integer :: kprc
+            integer :: lvlobje
+            double precision :: pivot
+            double precision :: step
+            integer :: ninf
+            double precision :: sinf
+            integer :: ninfe
+            double precision :: sinfe
+            double precision :: wtinf
+            integer :: nonopt
+            double precision :: objprt
+            double precision :: condzhz
+            double precision :: djqprt
+            double precision :: rgnorm
+            integer dimension(mbs) :: kbs
+            double precision dimension(mbs),depend(mbs) :: xbs
+            integer dimension(leniw) :: iw
+            integer, optional,check(len(iw)>=leniw),depend(iw) :: leniw=len(iw)
+        end subroutine sqlog
     end interface 
 end python module snopt
 


### PR DESCRIPTION
Addresses #21 by:
1. calling the SNOPT routine `snkerc` instead of `snoptc`
2. writing a custom `snstop` code in Python to replace the one supplied by SNOPT, and called every major iteration
3. wrapping the `snstop` Python code with f2py and passing it into `snkerc` since `snoptc` accepts much fewer inputs
4. modifying the db file structure such that the flag `isMajor` is set to true when the evaluation is at a major iteration
5. updating optview accordingly to filter iterations based on this flag

A few additional changes:
1. added code to retrieve the approximate Hessian from the SNOPT work array. Note this only works when full-memory Hessian option is used, as the memory layout in SNOPT is different otherwise
2. added code to retrieve the full vector of penalty parameters, containing entries for each of the constraints
3. storing these in the db file along with several other entries that could potentially be useful for users. The full list can be found in `snstop` and can be modified as needed, and it is straightforward to add more. Note that these entries are only present for major iterations.