### PR TITLE
Fix to skip the final and redundant SNOPT call

### DIFF
--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -545,6 +545,12 @@ class SNOPT(Optimizer):
         All we do here is call the generic masterFunc in the baseclass
         which will take care of everything else.
         """
+        # nState >=2 means this is the final call which is redundant
+        # here we just return without doing anything since we don't
+        # need to do any cleanup or anything
+        if nState >= 2:
+            return
+
         fail = False
         self.iu0 = iu[0]
         if mode == 0 or mode == 2:


### PR DESCRIPTION
## Purpose
Addresses #38 by simply returning without evaluation on the final call.

SNOPT was designed to do a final evaluation after terminating the main loop, so that if you needed to do any final clean up or file IO, this could be handled by your program. Since we don't need this functionality, we can remove the unnecessary (and very expensive!) function call. This call is signified by `nState =>2`, more specifically `nState = 2 + INFO/10` on the final call.
## Type of change

- Bugfix (non-breaking change which fixes an issue)

## Testing
SNOPT should now run optimization and exit without the extra function call. For example, with default options the `hs015` case should have the last `callCounter` be 20 instead of 21.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes
