### PR TITLE
changed conInfo and varInfo in db to OrderedDict to preserve key order

### DIFF
--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -27,6 +27,7 @@ from .pyOpt_solution import Solution
 from .pyOpt_optimization import INFINITY
 from .pyOpt_utils import convertToDense, convertToCOO, extractRows, \
     mapToCSC, scaleRows, IDATA
+from collections import OrderedDict
 eps = numpy.finfo(1.0).eps
 
 # =============================================================================
@@ -516,8 +517,8 @@ class Optimizer(object):
         # Add constraint and variable bounds at beginning of optimization.
         # This info is used for visualization using OptView.
         if self.callCounter == 0 and self.optProb.comm.rank == 0:
-            conInfo = {}
-            varInfo = {}
+            conInfo = OrderedDict()
+            varInfo = OrderedDict()
 
             # Cycle through constraints adding the bounds
             for key in self.optProb.constraints.keys():


### PR DESCRIPTION
## Purpose
The `conInfo` and `varInfo` dictionaries in the db file uses dictionaries and not OrderedDict, so the key order is inconsistent.  This is problematic if you are looping over the DVs or constraints using the keys of the dicts.

This PR addresses the issue by switching to using OrderedDicts. The keys in `varInfo` and `conInfo` now use the ordering in the `optProb`, which is also used elsewhere to write out the `xuser`, so they should all be consistent.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Bugfix (non-breaking change which fixes an issue)

## Testing
Key ordering in `varInfo` should always match those in `xuser`. `conInfo` should be consistent across multiple executions of the code.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes
