### PR TITLE
fixes strings in print out, in mProb,mObj,mRHS,mRng,mBnd

### DIFF
--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -465,7 +465,11 @@ class SNOPT(Optimizer):
             # Setup argument list values
             start = numpy.array(self.options['Start'][1])
             ObjAdd = numpy.array([0.], numpy.float)
-            ProbNm = numpy.array(self.optProb.name)
+            ProbNm = self.optProb.name
+            cw[51,:] = -1111111 # we set these to cdummy so that a placeholder is used in printout
+            cw[52,:] = -1111111
+            cw[53,:] = -1111111
+            cw[54,:] = -1111111
             xs = numpy.concatenate((xs, numpy.zeros(ncon, numpy.float)))
             bl = numpy.concatenate((blx, blc))
             bu = numpy.concatenate((bux, buc))

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -465,11 +465,12 @@ class SNOPT(Optimizer):
             # Setup argument list values
             start = numpy.array(self.options['Start'][1])
             ObjAdd = numpy.array([0.], numpy.float)
-            ProbNm = self.optProb.name
-            cw[51,:] = -1111111 # we set these to cdummy so that a placeholder is used in printout
-            cw[52,:] = -1111111
-            cw[53,:] = -1111111
-            cw[54,:] = -1111111
+            ProbNm = numpy.array(self.optProb.name,'c')	
+            cdummy = -1111111 # this is a magic variable defined in SNOPT for undefined strings
+            cw[51,:] = cdummy # we set these to cdummy so that a placeholder is used in printout
+            cw[52,:] = cdummy
+            cw[53,:] = cdummy
+            cw[54,:] = cdummy
             xs = numpy.concatenate((xs, numpy.zeros(ncon, numpy.float)))
             bl = numpy.concatenate((blx, blc))
             bu = numpy.concatenate((bux, buc))


### PR DESCRIPTION
## Purpose
Addresses #48. Two things were happening to the SNOPT_print.out
- The optimization name (which is specified as 8 characters) is often truncated incorrectly, or invalid characters are used as padding
- The section on Objective, RHS, Ranges and Bounds all display invalid characters

These cause problems when using meld/vi/diff since the encoding messes it up. This is fixed by this PR. First, the optProb name is directly passed in without casting it to a numpy character array, as f2py will automatically truncate or add the correct amount of padding. Second, the entries in `cw` that correspond to the names for the objective/RHS etc are set to the value of `cdummy` as found in SNOPT, so that internally in SNOPT they are replaced by a placeholder, in this case eight dashes.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Bugfix (non-breaking change which fixes an issue)

## Testing
Pull the code, run `test_hs015.py` and verify that these invalid characters do not appear on `SNOPT_print.out`.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes
