### PR TITLE
Cleaned up code for Lagrange multipliers

### DIFF
--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -1608,19 +1608,19 @@ class Optimization(object):
         if len(self.constraints) > 0:
 
             try: 
-                pi = self.pi 
-                pi_label = 'Pi'
+                lambdaStar = self.lambdaStar
+                lambdaStar_label = 'Lagrange Multiplier'
             except AttributeError: 
                 # the optimizer did not set the lagrange multipliers so set them to something obviously wrong 
                 n_c_total = sum([self.constraints[c].ncon for c in self.constraints])
-                pi = [9e100,]*n_c_total
-                pi_label = 'Pi(N/A)'
+                lambdaStar = [9e100,]*n_c_total
+                lambdaStar_label = 'Lagrange Multiplier (N/A)'
 
             text += '\n   Constraints (i - inequality, e - equality)\n'
             # Find the longest name in the constraints
             num_c = max([len(self.constraints[i].name) for i in self.constraints])
-            fmt = '    {0:>7s}  {1:{width}s} {2:>4s} {3:>14}  {4:>14}  {5:>14}  {6:>8s}  {7:>8s}\n'
-            text += fmt.format('Index', 'Name', 'Type', 'Lower', 'Value', 'Upper', 'Status', pi_label, width=num_c)
+            fmt = '    {0:>7s}  {1:{width}s} {2:>4s} {3:>14}  {4:>14}  {5:>14}  {6:>8s}  {7:>14s}\n'
+            text += fmt.format('Index', 'Name', 'Type', 'Lower', 'Value', 'Upper', 'Status', lambdaStar_label, width=num_c)
             fmt = '    {0:7d}  {1:{width}s} {2:>4s} {3:>14.6E}  {4:>14.6E}  {5:>14.6E}  {6:>8s}  {7:>14.5E}\n'
             idx = 0
             for iCon in self.constraints:
@@ -1629,7 +1629,6 @@ class Optimization(object):
                     lower = c.lower[j] if c.lower[j] is not None else -1.0E20
                     upper = c.upper[j] if c.upper[j] is not None else 1.0E20
                     value = c.value[j]
-                    lagrange_multiplier = pi[j]
                     status = ''
                     typ = 'e' if j in c.equalityConstraints['ind'] else 'i'
                     if typ == 'e':
@@ -1656,7 +1655,7 @@ class Optimization(object):
                             # Active upper bound
                             status += 'u'
 
-                    text += fmt.format(idx, c.name, typ, lower, value, upper, status, pi[idx], width=num_c)
+                    text += fmt.format(idx, c.name, typ, lower, value, upper, status, lambdaStar[idx], width=num_c)
                     idx += 1
 
         return text

--- a/pyoptsparse/pySLSQP/pySLSQP.py
+++ b/pyoptsparse/pySLSQP/pySLSQP.py
@@ -241,18 +241,20 @@ class SLSQP(Optimizer):
             #some entries of W include the lagrange multipliers 
             # for each constraint, there are two entries (lower, upper). 
             # if only one is active, look for the nonzero. If both are active, take the first one
-            pi = []
+            # FIXME: this does not currently work, so we do not save lambdaStar
+            # to the solution object
+            lambdaStar = []
             idx = 0
 
             for c_name in optProb.constraints: 
                 c = optProb.constraints[c_name]
                 for j in range(c.ncon): 
-                    pi_lower = w[2*idx]
-                    pi_upper = w[2*idx+1]
-                    if abs(pi_lower) > 1e-100: 
-                        pi.append(pi_lower)
+                    lambdaStar_lower = w[2*idx]
+                    lambdaStar_upper = w[2*idx+1]
+                    if abs(lambdaStar_lower) > 1e-100: 
+                        lambdaStar.append(lambdaStar_lower)
                     else: 
-                        pi.append(pi_upper) 
+                        lambdaStar.append(lambdaStar_upper) 
                     idx += 1
 
             
@@ -274,7 +276,7 @@ class SLSQP(Optimizer):
 
             # Create the optimization solution
             sol = self._createSolution(optTime, sol_inform, ff, xs)
-            sol.pi = pi
+
         else:  # We are not on the root process so go into waiting loop:
             self._waitLoop()
             sol = None

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -529,7 +529,6 @@ class SNOPT(Optimizer):
             sol = self._createSolution(optTime, sol_inform, ff, xs[:nvar],
                                        multipliers=pi)
 
-            sol.pi = pi # store the lagrange multipliers in the solution
 
         else:  # We are not on the root process so go into waiting loop:
             self._waitLoop()


### PR DESCRIPTION
… incorrect

## Purpose
This PR does the following:
* renamed `pi` to `lambdaStar` for the Lagrange multipliers
* removed saving the unscaled multipliers `pi` separately in `pySNOPT`
* removed saving the unscaled multipliers `pi` for SLSQP since they are not correct. We currently do not save any multiplier info for SLSQP
* changed the final print-out of the solution object to be more clear about multipliers

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes