### PR TITLE
Fix for requiring the six package

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -12,6 +12,7 @@ pyOpt has the following dependencies:
 * Swig 1.3+
 * c/FORTRAN compiler (compatible with f2py)
 * mpi4py
+* six 1.13
 
 Notes:
 

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -30,16 +30,15 @@ try:
 except ImportError:
     try:
         from ordereddict import OrderedDict
-    except ImportError:
-        print('Could not find any OrderedDict class. For 2.6 and earlier, \
+    except:
+        raise ImportError('Could not find any OrderedDict class. For 2.6 and earlier, \
 use:\n pip install ordereddict')
 
 try:
     import six
     from six import iteritems, iterkeys, next
-except ImportError:
-    six = None
-    print ('Could not import \'six\' OpenMDAO type tuple return not available.')
+except:
+    raise ImportError('Could not import \'six\'. To install, use\n pip install six')
 
 from .sqlitedict.sqlitedict import SqliteDict
 
@@ -1325,12 +1324,8 @@ class Optimization(object):
         gobj = numpy.zeros((nobj, self.ndvs))
 
         cond = False
-        if six:
-            # this version is required for python 3 compatibility
-            cond = isinstance(next(iterkeys(funcsSens)), str)
-        else:
-            # fallback if six is not available
-            cond = isinstance(funcsSens.keys()[0], str)
+        # this version is required for python 3 compatibility
+        cond = isinstance(next(iterkeys(funcsSens)), str)
 
         if cond:
             iObj = 0


### PR DESCRIPTION
## Purpose
Previously `six` was an optional dependency, but the code actually had it as a required dependency -- it will throw an error in some cases if `six` was not installed. See #61 for the issue.
This fix addresses the bug by explicitly requiring `six`. In the future, we may drop the dependency as we move to support only Python 3.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Bugfix (non-breaking change which fixes an issue)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.
Running the tests as explained in #61 without `six` installed should now raise an error, with instructions to install it.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added necessary documentation
