### PR TITLE
Added version number to the module

### DIFF
--- a/pyoptsparse/__init__.py
+++ b/pyoptsparse/__init__.py
@@ -24,3 +24,5 @@ from .pyALPSO.pyALPSO import ALPSO
 from .pyParOpt import ParOpt
 # from .pyNOMAD.pyNOMAD import NOMAD
 from .sqlitedict.sqlitedict import SqliteDict
+
+__version__ = '1.1.0'

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ if __name__ == '__main__':
 
     setup(
         name             = 'pyoptsparse',
-        version          = '1.0.0',
+        version          = '1.1.0',
         author           = 'Dr. Gaetan Kenway',
         author_email     = 'gaetank@gmail.com',
         maintainer       = 'Dr. Gaetan Kenway',

--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,16 @@ def configuration(parent_package='', top_path=None):
 
 if __name__ == '__main__':
 
+    import re
+
+    __version__ = re.findall(
+        r"""__version__ = ["']+([0-9\.]*)["']+""",
+        open('pyoptsparse/__init__.py').read(),
+    )[0]
+
     setup(
         name             = 'pyoptsparse',
-        version          = '1.1.0',
+        version          = __version__,
         author           = 'Dr. Gaetan Kenway',
         author_email     = 'gaetank@gmail.com',
         maintainer       = 'Dr. Gaetan Kenway',


### PR DESCRIPTION
## Purpose
This PR adds __version__ to the main module so that other packages can check the version of the installed pyoptsparse by querying "pyoptsparse.__version__".  (PEP 396 defines this standard.)

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_
- Other (please describe)
This is a fix that further supports pyoptsparse usage as a python package. Adding __version__ allows the version to be queried automatically.  I also updated the version number in setup.py.

Note: These changes make a properly versioned release, so the current 1.1.0 release should be replaced with this commit. You could also choose to increment the release, maybe 1.1.1, but you will have to update the version number in both places.

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.
No tests needed.

## Checklist
_Put an `x` in the boxes that apply._

- [x ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
