### PR TITLE
mpi4py import

### DIFF
--- a/pyoptsparse/pyParOpt/ParOpt.py
+++ b/pyoptsparse/pyParOpt/ParOpt.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import numpy as np
-from mpi4py import MPI
 
 try:
     from paropt import ParOpt as _ParOpt
+    from mpi4py import MPI
 except ImportError:
     _ParOpt = None
 


### PR DESCRIPTION
## Purpose
ParOpt requires mpi4py. However, we do not want this to be a requirement for those who do not need ParOpt. Therefore, the import statement has been moved to a try block so that it's not needed if you don't run ParOpt.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Bugfix (non-breaking change which fixes an issue)

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes