### PR TITLE
Add coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
   # We need to source the mdolab bashrc before running anything
   - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && testflo --pre_announce -v . --coverage --coverpkg pyoptsparse --cover-omit \*tests/\* --cover-omit \*docs/\*"
 
-#after_success:
-#  - docker exec -it app /bin/bash -c "pip install coveralls"
-#  - docker exec -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" -it app /bin/bash -c 
-#    ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && coveralls"
+after_success:
+  - docker exec -it app /bin/bash -c "pip install python-coveralls"
+  - docker exec -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" -it app /bin/bash -c 
+    ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,6 @@ script:
   - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && testflo --pre_announce -v . --coverage --coverpkg pyoptsparse --cover-omit \*tests/\* --cover-omit \*docs/\*"
 
 after_success:
-  - docker exec -it app /bin/bash -c "pip install python-coveralls"
+  - docker exec -it app /bin/bash -c "pip install coveralls python-coveralls"
   - docker exec -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" -it app /bin/bash -c 
     ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,4 @@ script:
 after_success:
   - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && pip install coveralls"
   - docker exec -e COVERALLS_REPO_TOKEN="$COVERALLS_REPO_TOKEN" -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" -it app /bin/bash -c 
-    ". \$HOME/.bashrc_mdolab && echo \$COVERALLS_REPO_TOKEN && cd $DOCKER_WORKING_DIR && coveralls"
+    ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-os:
+\$Hos:
 - linux
 
 language: generic
@@ -39,7 +39,7 @@ install:
   - docker exec -it app /bin/bash -c "rm -rf $DOCKER_WORKING_DIR && cp -r $DOCKER_MOUNT_DIR $DOCKER_WORKING_DIR"
   - docker exec -it app /bin/bash -c "cp -r \$HOME/NLPQLP/* $NLPQLP_DIR/ && cp -r \$HOME/SNOPT/* $SNOPT_DIR/ && cp -r \$HOME/IPOPT/ $IPOPT_DIR"
   - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && python setup.py build_ext --inplace && python setup.py install --user"
-script:testflo --pre_announce -v . --coverage --coverpkg pyoptsparse
+script:
   # We need to source the mdolab bashrc before running anything
   - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && testflo --pre_announce -v . --coverage --coverpkg pyoptsparse --cover-omit \*tests/\* --cover-omit \*docs/\*"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,13 @@ install:
   # We thrown away the existing repo in Docker, and copy the new one in-place
   - docker exec -it app /bin/bash -c "rm -rf $DOCKER_WORKING_DIR && cp -r $DOCKER_MOUNT_DIR $DOCKER_WORKING_DIR"
   - docker exec -it app /bin/bash -c "cp -r \$HOME/NLPQLP/* $NLPQLP_DIR/ && cp -r \$HOME/SNOPT/* $SNOPT_DIR/ && cp -r \$HOME/IPOPT/ $IPOPT_DIR"
-  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && python setup.py build_ext --inplace && python setup.py install --user"
+  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc && cd $DOCKER_WORKING_DIR && python setup.py build_ext --inplace && python setup.py install --user"
 script:
   # We need to source the mdolab bashrc before running anything
-  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && testflo --pre_announce -v . --coverage --coverpkg pyoptsparse --cover-omit \*tests/\* --cover-omit \*docs/\*"
+  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc && cd $DOCKER_WORKING_DIR && testflo --pre_announce -v . --coverage --coverpkg pyoptsparse --cover-omit \*tests/\* --cover-omit \*docs/\*"
 
 after_success:
-  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && pip install coveralls"
+  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc && pip install coveralls"
   # These environment variables must be exposed to coveralls for it to work (since we are on Docker)
   - docker exec -e COVERALLS_REPO_TOKEN="$COVERALLS_REPO_TOKEN" -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" -it app /bin/bash -c 
-    ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && coveralls"
+    ". \$HOME/.bashrc && cd $DOCKER_WORKING_DIR && coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,5 +45,6 @@ script:
 
 after_success:
   - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && pip install coveralls"
+  # These environment variables must be exposed to coveralls for it to work (since we are on Docker)
   - docker exec -e COVERALLS_REPO_TOKEN="$COVERALLS_REPO_TOKEN" -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" -it app /bin/bash -c 
     ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-\$Hos:
+os:
 - linux
 
 language: generic
@@ -45,5 +45,5 @@ script:
 
 after_success:
   - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && pip install coveralls"
-  - docker exec -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" -it app /bin/bash -c 
-    ". \$HOME/.bashrc_mdolab && echo \$TRAVIS_JOB_ID && echo \$TRAVIS_BRANCH && cd $DOCKER_WORKING_DIR && coveralls"
+  - docker exec -e COVERALLS_REPO_TOKEN="$COVERALLS_REPO_TOKEN" -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" -it app /bin/bash -c 
+    ". \$HOME/.bashrc_mdolab && echo \$COVERALLS_REPO_TOKEN && cd $DOCKER_WORKING_DIR && coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,4 @@ script:
 after_success:
   - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && pip install coveralls"
   - docker exec -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" -it app /bin/bash -c 
-    ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && coveralls"
+    ". \$HOME/.bashrc_mdolab && echo \$TRAVIS_JOB_ID && echo \$TRAVIS_BRANCH && cd $DOCKER_WORKING_DIR && coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,11 @@ install:
   - docker exec -it app /bin/bash -c "rm -rf $DOCKER_WORKING_DIR && cp -r $DOCKER_MOUNT_DIR $DOCKER_WORKING_DIR"
   - docker exec -it app /bin/bash -c "cp -r \$HOME/NLPQLP/* $NLPQLP_DIR/ && cp -r \$HOME/SNOPT/* $SNOPT_DIR/ && cp -r \$HOME/IPOPT/ $IPOPT_DIR"
   - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && python setup.py build_ext --inplace && python setup.py install --user"
-script:
+script:testflo --pre_announce -v . --coverage --coverpkg pyoptsparse
   # We need to source the mdolab bashrc before running anything
   - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && testflo --pre_announce -v . --coverage --coverpkg pyoptsparse --cover-omit \*tests/\* --cover-omit \*docs/\*"
 
 after_success:
-  - docker exec -it app /bin/bash -c "pip install coveralls python-coveralls"
+  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && pip install coveralls"
   - docker exec -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" -it app /bin/bash -c 
     ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && coveralls"


### PR DESCRIPTION
## Purpose
Links to coveralls.io has been added. There's a corresponding environment variable called COVERALLS_REPO_TOKEN which tells coveralls where to push the coverage info.

Perhaps we can talk about which folder/files we would like to omit, and maybe configure the .coveragerc file similar to how openMDAO handles it?

Also please squash this PR.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_
## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes
