### PR TITLE
Removed storing git hash in history file

### DIFF
--- a/doc/api/history.rst
+++ b/doc/api/history.rst
@@ -14,8 +14,7 @@ In this case, the history file would have the following layout::
     │   ├── endTime
     │   ├── optTime
     │   ├── optimizer
-    │   ├── version
-    │   └── gitHash
+    │   └── version
     ├── varInfo
     │   └── xvars
     │       ├── lower

--- a/pyoptsparse/__init__.py
+++ b/pyoptsparse/__init__.py
@@ -23,4 +23,4 @@ from .pyALPSO.pyALPSO import ALPSO
 from .pyParOpt import ParOpt
 # from .pyNOMAD.pyNOMAD import NOMAD
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -559,13 +559,6 @@ class Optimizer(object):
                 # we retrieve only the second item which is the actual value
                 for key,val in options.items():
                     options[key] = val[1]
-                # retrieve the git commit hash of the current version of pyoptsparse
-                try:
-                    sha = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'])
-                    sha = str(sha,'utf-8').replace('\n','') # converting byte to string, then trimming the newline character
-                except:
-                    # Not a git repo, perhaps the code was downloaded directly from GitHub instead of cloned
-                    sha = None
                 # we store the metadata now, and write it later in optimizer calls
                 # since we need the runtime at the end of optimization
                 self.metadata = {
@@ -575,7 +568,6 @@ class Optimizer(object):
                     'nprocs'    : MPI.COMM_WORLD.size,
                     'optOptions': options,
                     'startTime' : datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-                    'gitHash'   : sha,
                 }
                 self.hist.writeData('metadata',self.metadata)
 


### PR DESCRIPTION
If the package has been installed in the default `site-packages` folder, then git is not able to find the git commit hash since it is not the source code folder where git lives. The git hash is then empty in most cases, which is not very useful. More worryingly, this seem to trigger some PETSc segfaults in some cases -- we haven't fully debugged this yet, as the behavior seems to be nondeterministic. However, to be safe, we have decided to remove this feature. We aim to increment the package version more frequently in the future to provide a more meaningful way of keeping track of code versions.