### PR TITLE
Bugfix for hotstart when also saving history file

### DIFF
--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -30,6 +30,7 @@ from .pyOpt_utils import convertToDense, convertToCOO, extractRows, \
 from collections import OrderedDict
 import datetime
 import subprocess
+from .pyOpt_MPI import MPI
 eps = numpy.finfo(numpy.float64).eps
 
 # =============================================================================
@@ -182,6 +183,9 @@ class Optimizer(object):
                     self.hist.writeData('conInfo', conInfo)
                 if objInfo is not None:
                     self.hist.writeData('objInfo', objInfo)
+                self._setMetadata()
+                self.hist.writeData('metadata',self.metadata)
+
 
     def _masterFunc(self, x, evaluate):
         """
@@ -551,24 +555,7 @@ class Optimizer(object):
                 self.hist.writeData('varInfo', varInfo)
                 self.hist.writeData('conInfo', conInfo)
                 self.hist.writeData('objInfo', objInfo)
-                # we also add some metadata
-                from pyoptsparse import __version__ as pyoptsparse_version
-                from .pyOpt_MPI import MPI
-                options = copy.deepcopy(self.options)
-                options.pop('defaults') # remove the default list
-                # we retrieve only the second item which is the actual value
-                for key,val in options.items():
-                    options[key] = val[1]
-                # we store the metadata now, and write it later in optimizer calls
-                # since we need the runtime at the end of optimization
-                self.metadata = {
-                    'version'   : pyoptsparse_version,
-                    'optimizer' : self.name,
-                    'optName'   : self.optProb.name,
-                    'nprocs'    : MPI.COMM_WORLD.size,
-                    'optOptions': options,
-                    'startTime' : datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-                }
+                self._setMetadata()
                 self.hist.writeData('metadata',self.metadata)
 
         # Write history if necessary
@@ -796,6 +783,31 @@ class Optimizer(object):
         sol.comm = self.optProb.comm
 
         return sol
+    
+    def _setMetadata(self):
+        """
+        This function is used to set the self.metadata object.
+        Importantly, this sets the startTime, so should be called just before the start
+        of the optimization. endTime should be directly appended to the dictionary
+        after optimization finishes.
+        """
+        options = copy.deepcopy(self.options)
+        options.pop('defaults') # remove the default list
+        # we retrieve only the second item which is the actual value
+        for key,val in options.items():
+            options[key] = val[1]
+        
+        from .__init__ import __version__ # importing the pyoptsparse version
+        # we store the metadata now, and write it later in optimizer calls
+        # since we need the runtime at the end of optimization
+        self.metadata = {
+            'version'   : __version__,
+            'optimizer' : self.name,
+            'optName'   : self.optProb.name,
+            'nprocs'    : MPI.COMM_WORLD.size,
+            'optOptions': options,
+            'startTime' : datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        }
 
     def _on_setOption(self, name, value):
         """

--- a/test/test_hs015.py
+++ b/test/test_hs015.py
@@ -74,11 +74,15 @@ class TestHS15(unittest.TestCase):
             raise unittest.SkipTest('Optimizer not available:', optName)
 
         # Solution
-        if storeHistory:
-            self.histFileName = '%s_hs015_Hist.hst' % (optName.lower())
+        if storeHistory is not None:
+            if storeHistory == True:
+                self.histFileName = '%s_hs015_Hist.hst' % (optName.lower())
+            elif isinstance(storeHistory,str):
+                self.histFileName = storeHistory
         else:
             self.histFileName = None
-
+        print('histFileName: ', self.histFileName)
+        print('hotStart: ', hotStart)
         sol = opt(optProb, sens=self.sens, storeHistory=self.histFileName, hotStart=hotStart)
 
         # Test printing solution to screen
@@ -118,6 +122,16 @@ class TestHS15(unittest.TestCase):
             self.assertIn(var,hist['19'].keys())
         # re-optimize with hotstart
         self.optimize('snopt',storeHistory=False,hotStart=self.histFileName)
+        # now we should do the same optimization without calling them
+        self.assertEqual(self.nf,0)
+        self.assertEqual(self.ng,0)
+        # another test with hotstart, this time with storeHistory = hotStart
+        self.optimize('snopt',storeHistory=True,hotStart=self.histFileName)
+        # now we should do the same optimization without calling them
+        self.assertEqual(self.nf,0)
+        self.assertEqual(self.ng,0)
+        # final test with hotstart, this time with a different storeHistory
+        self.optimize('snopt',storeHistory='snopt_new_hotstart.hst',hotStart=self.histFileName)
         # now we should do the same optimization without calling them
         self.assertEqual(self.nf,0)
         self.assertEqual(self.ng,0)


### PR DESCRIPTION
## Purpose
There was a bug in release v2.0.1 involving hotstarts. Due to the way the hotstart is implemented, the history file is created elsewhere and various keys are copied over. The newly-added `metadata` key was not added, and therefore at the end of the optimization the `self.metadata` key cannot be found. This is now fixed.

To be clear, the issue affected cases with *both* `hotStart` and `storeHistory` enabled.


## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Bugfix (non-breaking change which fixes an issue)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works