### PR TITLE
Fixing optimization scaling in solution object

### DIFF
--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -763,7 +763,6 @@ class Optimizer(object):
             # objective scaling
             if len(self.optProb.objectives.keys()) == 1: # we assume there is only one objective
                 obj = list(self.optProb.objectives.keys())[0]
-                sol.fStar = self.optProb.objectives[obj].value # FIXME we actually populate fStar here, very hacky
                 for con in multipliers.keys():
                     multipliers[con] /= self.optProb.objectives[obj].scale
             sol.lambdaStar = multipliers

--- a/test/test_hs071.py
+++ b/test/test_hs071.py
@@ -58,7 +58,7 @@ class TestHS71(unittest.TestCase):
         sol = opt(optProb, sens=sens)
 
         # Check Solution
-        self.assertAlmostEqual(sol.fStar, 17.0140172, places=places)
+        self.assertAlmostEqual(sol.objectives['obj'].value, 17.0140172, places=places)
 
         self.assertAlmostEqual(sol.xStar['xvars'][0], 1.0, places=places)
         self.assertAlmostEqual(sol.xStar['xvars'][1], 4.743, places=places)

--- a/test/test_hs071.py
+++ b/test/test_hs071.py
@@ -35,19 +35,19 @@ def sens(xdict, funcs):
 
 class TestHS71(unittest.TestCase):
 
-    def optimize(self, optName, optOptions={}, storeHistory=False, places=5):
+    def optimize(self, optName, optOptions={}, storeHistory=False, places=5, xScale=1.0, objScale=1.0, conScale=1.0):
         # Optimization Object
         optProb = Optimization('HS071 Constraint Problem', objfunc)
 
         # Design Variables
         x0 = [1.0, 5.0, 5.0, 1.0]
-        optProb.addVarGroup('xvars', 4, lower=1, upper=5, value=x0)
+        optProb.addVarGroup('xvars', 4, lower=1, upper=5, value=x0, scale=xScale)
 
         # Constraints
-        optProb.addConGroup('con', 2, lower=[25, 40], upper=[None, 40])
+        optProb.addConGroup('con', 2, lower=[25, 40], upper=[None, 40], scale=conScale)
 
         # Objective
-        optProb.addObj('obj')
+        optProb.addObj('obj', scale=objScale)
 
         # Optimizer
         try:
@@ -58,12 +58,12 @@ class TestHS71(unittest.TestCase):
         sol = opt(optProb, sens=sens)
 
         # Check Solution
-        self.assertAlmostEqual(sol.objectives['obj'].value, 17.0140172, places=places)
+        self.assertAlmostEqual(sol.fStar, 17.0140172, places=places)
 
-        self.assertAlmostEqual(sol.variables['xvars'][0].value, 1.0, places=places)
-        self.assertAlmostEqual(sol.variables['xvars'][1].value, 4.743, places=places)
-        self.assertAlmostEqual(sol.variables['xvars'][2].value, 3.82115, places=places)
-        self.assertAlmostEqual(sol.variables['xvars'][3].value, 1.37941, places=places)
+        self.assertAlmostEqual(sol.xStar['xvars'][0], 1.0, places=places)
+        self.assertAlmostEqual(sol.xStar['xvars'][1], 4.743, places=places)
+        self.assertAlmostEqual(sol.xStar['xvars'][2], 3.82115, places=places)
+        self.assertAlmostEqual(sol.xStar['xvars'][3], 1.37941, places=places)
 
         if hasattr(sol, 'lambdaStar'):
             self.assertAlmostEqual(sol.lambdaStar['con'][0], 0.55229366, places=places)
@@ -71,6 +71,9 @@ class TestHS71(unittest.TestCase):
 
     def test_snopt(self):
         self.optimize('snopt')
+    
+    def test_snopt_scaling(self):
+        self.optimize('snopt', objScale=4.2, xScale=[2,3,4,5], conScale=[0.6, 1.7])
 
     def test_slsqp(self):
         self.optimize('slsqp')


### PR DESCRIPTION
## Purpose
Previously the values stored in the solution object was not scaled back. When scaling is applied, the final solution values change. This PR ensures that the objective, DV, and Lagrange multiplier values stay the same when objective, constraints and DVs are arbitrarily scaled.

Note: the `sol.fStar` field is broken (same as before). I did not have time to debug the issue.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Bugfix (non-breaking change which fixes an issue)

## Testing
See the newly-added test `test_snopt_scaling`.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works