### PR TITLE
readthedocs update

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,7 +16,7 @@ import sys, os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('../'))
+sys.path.insert(0, os.path.abspath('../'))
 
 # -- General configuration -----------------------------------------------------
 
@@ -92,10 +92,10 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme_path = ['themes']
-html_theme = 'mdolab_theme'
+# html_theme_path = ['themes']
+# html_theme = 'mdolab_theme'
 
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/optimizers/pyalpso.rst
+++ b/doc/optimizers/pyalpso.rst
@@ -1,7 +1,7 @@
 .. _alpso:
 
 ALPSO
-======
+=====
 Augmented Lagrangian Particle Swarm Optimizer (ALPSO) is a PSO method that uses the augmented Lagrangian approach to handle constraints.
 
 API


### PR DESCRIPTION
## Purpose
Minor fixes for the documentation to work with readthedocs:
* added the parent folder of `docs` to the `sys.path`, so autodoc can find the modules
* removed current theme, may want to delete the directory in the future, i.e. not ship custom themes with the package

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Documentation update