### PR TITLE
Fix for inconsistent shape in return from getValues

### DIFF
--- a/pyoptsparse/pyOpt_history.py
+++ b/pyoptsparse/pyOpt_history.py
@@ -465,13 +465,14 @@ class History(object):
 
     def getValues(self, names=None, callCounters=None, major=True, scale=False, stack=False):
         """
-        Parses an existing history file and returns a data dictionary used to post-process optimization results.
+        Parses an existing history file and returns a data dictionary used to post-process optimization results, containing the requested optimization iteration history.
 
         Parameters
         ----------
         names : list or str
             the values of interest, can be the name of any DV, objective or constraint,
-            or a list of them. If None, all values are returned.
+            or a list of them. If None, all values are returned. This includes the DVs,
+            funcs, and any values stored by the optimizer.
         
         callCounters : list of ints, can also contain 'last'
             a list of callCounters to extract information from.
@@ -489,6 +490,13 @@ class History(object):
         stack : bool
             flag to specify whether the DV should be stacked into a single numpy array with
             the key `xuser`, or retain their separate DVGroups.
+
+        Returns
+        -------
+        dict
+            a dictionary containing the information requested. The keys of the dictionary
+            correspond to the `names` requested. Each value is a numpy array with the first
+            dimension equal to the number of callCounters requested.
 
         Notes
         -----
@@ -593,17 +601,8 @@ class History(object):
                 pyOptSparseWarning(("callCounter {} was not found and is skipped!").format(i))
         # reshape lists into numpy arrays
         for name in names:
-            # if we have more than one callCounter
-            if len(callCounters) > 1:
-                # if it is a list of floats or numpy 1-D array then we just cast to 1-D array
-                if isinstance(data[name][0],float) or (isinstance(data[name][0],numpy.ndarray) and data[name][0].ndim == 1):
-                    data[name] = numpy.array(data[name])
-                # otherwise convert to 2-D array
-                else:
-                    data[name] = numpy.vstack(data[name])
-            # if one callCounter then use a simple 1-D array also
-            else:
-                data[name] = numpy.array(data[name][0])
+            # we just stack along axis 0
+            data[name] = numpy.stack(data[name],axis=0)
 
             # scale the values if needed
             # note that xuser has already been scaled

--- a/pyoptsparse/pyOpt_history.py
+++ b/pyoptsparse/pyOpt_history.py
@@ -498,7 +498,7 @@ class History(object):
         --------
         First we can request DV history over all major iterations:
 
-        >>> hist.getValues(names='xvars')
+        >>> hist.getValues(names='xvars', major=True)
         {'xvars': array([[-2.00000000e+00,  1.00000000e+00],
             [-1.00000000e+00,  9.00000000e-01],
             [-5.00305827e-17,  4.21052632e-01],

--- a/test/test_hs015.py
+++ b/test/test_hs015.py
@@ -2,8 +2,8 @@
 from __future__ import print_function
 
 import unittest
-
 import numpy as np
+from numpy.testing import assert_almost_equal
 from pyoptsparse import Optimization, OPT, History
 from sqlitedict import SqliteDict
 class TestHS15(unittest.TestCase):
@@ -44,7 +44,7 @@ class TestHS15(unittest.TestCase):
         fail = False
         return funcsSens, fail
 
-    def optimize(self, optName, optOptions={}, storeHistory=False,places=12, hotStart=None):
+    def optimize(self, optName, optOptions={}, storeHistory=False,decimal=12, hotStart=None):
         self.nf = 0 # number of function evaluations
         self.ng = 0 # number of gradient evaluations
         # Optimization Object
@@ -90,22 +90,22 @@ class TestHS15(unittest.TestCase):
         # Check Solution
         self.fStar1 = 306.5
         self.fStar2 = 360.379767
-        fobj = sol.objectives['obj'].value
-        diff = np.min(np.abs([fobj - self.fStar1, fobj - self.fStar2]))
-        self.assertAlmostEqual(diff, 0.0, places=places)
 
         self.xStar1 = (0.5, 2.0)
         self.xStar2 = (-0.79212322, -1.26242985)
 
         dv = sol.getDVs()
-        for i in range(2):
-            self.assertAlmostEqual(sol.variables['xvars'][i].value, dv['xvars'][i], places=10)
+        sol_xvars = [sol.variables['xvars'][i].value for i in range(2)]
+        assert_almost_equal(sol_xvars, dv['xvars'], decimal=decimal)
+        # we check either optimum via try/except
+        try:
+            assert_almost_equal(sol.objectives['obj'].value, self.fStar1, decimal=decimal)
+            assert_almost_equal(dv['xvars'], self.xStar1, decimal=decimal)
+        except:
+            assert_almost_equal(sol.objectives['obj'].value, self.fStar2, decimal=decimal)
+            assert_almost_equal(dv['xvars'], self.xStar2, decimal=decimal)
 
-            diff = np.min(np.abs([self.xStar1[i] - sol.variables['xvars'][i].value,
-                                self.xStar2[i] - sol.variables['xvars'][i].value]))
-            self.assertAlmostEqual(diff, 0.0, places=places)
-
-    def check_hist_file(self, optimizer, places=12):
+    def check_hist_file(self, optimizer, decimal=12):
         """
         We check the history file here along with the API
         """
@@ -152,32 +152,31 @@ class TestHS15(unittest.TestCase):
             self.assertTrue(val['isMajor'][0]) # the first callCounter must be a major iteration
             self.assertTrue(val['isMajor'][-1]) # the last callCounter must be a major iteration
             # check optimum stored in history file against xstar
-            self.assertAlmostEqual(val['xuser'][-1,0],self.xStar1[0], places=places)
-            self.assertAlmostEqual(val['xuser'][-1,1],self.xStar1[1], places=places)
+            assert_almost_equal(val['xuser'][-1],self.xStar1, decimal=decimal)
 
-    def optimize_with_hotstart(self,optName,places=12,optOptions={}):
+    def optimize_with_hotstart(self,optName,decimal=12,optOptions={}):
         """
         This code will perform 4 optimizations, one real opt and three restarts.
         In this process, it will check various combinations of storeHistory and hotStart filenames.
         It will also call `check_hist_file` after the first optimization.
         """
-        self.optimize(optName,storeHistory=True,optOptions=optOptions,places=places)
+        self.optimize(optName,storeHistory=True,optOptions=optOptions,decimal=decimal)
         self.assertGreater(self.nf,0)
         self.assertGreater(self.ng,0)
-        self.check_hist_file(optName, places=places)
+        self.check_hist_file(optName, decimal=decimal)
 
         # re-optimize with hotstart
-        self.optimize(optName,storeHistory=False,hotStart=self.histFileName,optOptions=optOptions,places=places)
+        self.optimize(optName,storeHistory=False,hotStart=self.histFileName,optOptions=optOptions,decimal=decimal)
         # we should have zero actual function/gradient evaluations
         self.assertEqual(self.nf,0)
         self.assertEqual(self.ng,0)
         # another test with hotstart, this time with storeHistory = hotStart
-        self.optimize(optName,storeHistory=True,hotStart=self.histFileName,places=places)
+        self.optimize(optName,storeHistory=True,hotStart=self.histFileName,decimal=decimal)
         # we should have zero actual function/gradient evaluations
         self.assertEqual(self.nf,0)
         self.assertEqual(self.ng,0)
         # final test with hotstart, this time with a different storeHistory
-        self.optimize(optName,storeHistory='{}_new_hotstart.hst'.format(optName),hotStart=self.histFileName,places=places)
+        self.optimize(optName,storeHistory='{}_new_hotstart.hst'.format(optName),hotStart=self.histFileName,decimal=decimal)
         # we should have zero actual function/gradient evaluations
         self.assertEqual(self.nf,0)
         self.assertEqual(self.ng,0)
@@ -185,7 +184,7 @@ class TestHS15(unittest.TestCase):
     def test_snopt(self):
         store_vars = ['step','merit','feasibility','optimality','penalty','Hessian','condZHZ','slack','lambda']
         optOptions = {'Save major iteration variables': store_vars}
-        self.optimize_with_hotstart('SNOPT', places=12, optOptions=optOptions)
+        self.optimize_with_hotstart('SNOPT', decimal=12, optOptions=optOptions)
 
         hist = History(self.histFileName, flag='r')
         data = hist.getValues(callCounters=['last'])
@@ -200,24 +199,24 @@ class TestHS15(unittest.TestCase):
         self.assertEqual(data['lambda'].shape,(1,2))
 
     def test_slsqp(self):
-        self.optimize_with_hotstart('SLSQP', places=8)
+        self.optimize_with_hotstart('SLSQP', decimal=8)
 
     def test_nlpqlp(self):
-        self.optimize_with_hotstart('NLPQLP', places=12)
+        self.optimize_with_hotstart('NLPQLP', decimal=12)
 
     def test_ipopt(self):
-        self.optimize_with_hotstart('IPOPT', places=4)
+        self.optimize_with_hotstart('IPOPT', decimal=4)
 
     def test_paropt(self):
-        self.optimize_with_hotstart('ParOpt', places=6)
+        self.optimize_with_hotstart('ParOpt', decimal=6)
 
     def test_conmin(self):
         opts = {'DELFUN' : 1e-10,
                 'DABFUN' : 1e-10}
-        self.optimize_with_hotstart('CONMIN', places=10, optOptions=opts)
+        self.optimize_with_hotstart('CONMIN', decimal=10, optOptions=opts)
 
     def test_psqp(self):
-        self.optimize_with_hotstart('PSQP', places=12)
+        self.optimize_with_hotstart('PSQP', decimal=12)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_hs015.py
+++ b/test/test_hs015.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 from pyoptsparse import Optimization, OPT, History
 from sqlitedict import SqliteDict
 class TestHS15(unittest.TestCase):
@@ -44,7 +44,7 @@ class TestHS15(unittest.TestCase):
         fail = False
         return funcsSens, fail
 
-    def optimize(self, optName, optOptions={}, storeHistory=False,decimal=12, hotStart=None):
+    def optimize(self, optName, tol, optOptions={}, storeHistory=False, hotStart=None):
         self.nf = 0 # number of function evaluations
         self.ng = 0 # number of gradient evaluations
         # Optimization Object
@@ -96,16 +96,16 @@ class TestHS15(unittest.TestCase):
 
         dv = sol.getDVs()
         sol_xvars = [sol.variables['xvars'][i].value for i in range(2)]
-        assert_almost_equal(sol_xvars, dv['xvars'], decimal=decimal)
+        assert_allclose(sol_xvars, dv['xvars'], atol = tol, rtol = tol)
         # we check either optimum via try/except
         try:
-            assert_almost_equal(sol.objectives['obj'].value, self.fStar1, decimal=decimal)
-            assert_almost_equal(dv['xvars'], self.xStar1, decimal=decimal)
+            assert_allclose(sol.objectives['obj'].value, self.fStar1, atol = tol, rtol = tol)
+            assert_allclose(dv['xvars'], self.xStar1, atol = tol, rtol = tol)
         except:
-            assert_almost_equal(sol.objectives['obj'].value, self.fStar2, decimal=decimal)
-            assert_almost_equal(dv['xvars'], self.xStar2, decimal=decimal)
+            assert_allclose(sol.objectives['obj'].value, self.fStar2, atol = tol, rtol = tol)
+            assert_allclose(dv['xvars'], self.xStar2, atol = tol, rtol = tol)
 
-    def check_hist_file(self, optimizer, decimal=12):
+    def check_hist_file(self, optimizer, tol):
         """
         We check the history file here along with the API
         """
@@ -152,31 +152,31 @@ class TestHS15(unittest.TestCase):
             self.assertTrue(val['isMajor'][0]) # the first callCounter must be a major iteration
             self.assertTrue(val['isMajor'][-1]) # the last callCounter must be a major iteration
             # check optimum stored in history file against xstar
-            assert_almost_equal(val['xuser'][-1],self.xStar1, decimal=decimal)
+            assert_allclose(val['xuser'][-1],self.xStar1, atol = tol, rtol = tol)
 
-    def optimize_with_hotstart(self,optName,decimal=12,optOptions={}):
+    def optimize_with_hotstart(self,optName,tol,optOptions={}):
         """
         This code will perform 4 optimizations, one real opt and three restarts.
         In this process, it will check various combinations of storeHistory and hotStart filenames.
         It will also call `check_hist_file` after the first optimization.
         """
-        self.optimize(optName,storeHistory=True,optOptions=optOptions,decimal=decimal)
+        self.optimize(optName,tol,storeHistory=True,optOptions=optOptions, )
         self.assertGreater(self.nf,0)
         self.assertGreater(self.ng,0)
-        self.check_hist_file(optName, decimal=decimal)
+        self.check_hist_file(optName, tol)
 
         # re-optimize with hotstart
-        self.optimize(optName,storeHistory=False,hotStart=self.histFileName,optOptions=optOptions,decimal=decimal)
+        self.optimize(optName,tol,storeHistory=False,hotStart=self.histFileName,optOptions=optOptions)
         # we should have zero actual function/gradient evaluations
         self.assertEqual(self.nf,0)
         self.assertEqual(self.ng,0)
         # another test with hotstart, this time with storeHistory = hotStart
-        self.optimize(optName,storeHistory=True,hotStart=self.histFileName,decimal=decimal)
+        self.optimize(optName,tol,storeHistory=True,hotStart=self.histFileName)
         # we should have zero actual function/gradient evaluations
         self.assertEqual(self.nf,0)
         self.assertEqual(self.ng,0)
         # final test with hotstart, this time with a different storeHistory
-        self.optimize(optName,storeHistory='{}_new_hotstart.hst'.format(optName),hotStart=self.histFileName,decimal=decimal)
+        self.optimize(optName,tol,storeHistory='{}_new_hotstart.hst'.format(optName),hotStart=self.histFileName)
         # we should have zero actual function/gradient evaluations
         self.assertEqual(self.nf,0)
         self.assertEqual(self.ng,0)
@@ -184,7 +184,7 @@ class TestHS15(unittest.TestCase):
     def test_snopt(self):
         store_vars = ['step','merit','feasibility','optimality','penalty','Hessian','condZHZ','slack','lambda']
         optOptions = {'Save major iteration variables': store_vars}
-        self.optimize_with_hotstart('SNOPT', decimal=12, optOptions=optOptions)
+        self.optimize_with_hotstart('SNOPT', 1E-12, optOptions=optOptions)
 
         hist = History(self.histFileName, flag='r')
         data = hist.getValues(callCounters=['last'])
@@ -199,24 +199,24 @@ class TestHS15(unittest.TestCase):
         self.assertEqual(data['lambda'].shape,(1,2))
 
     def test_slsqp(self):
-        self.optimize_with_hotstart('SLSQP', decimal=8)
+        self.optimize_with_hotstart('SLSQP', 1E-8)
 
     def test_nlpqlp(self):
-        self.optimize_with_hotstart('NLPQLP', decimal=12)
+        self.optimize_with_hotstart('NLPQLP', 1E-12)
 
     def test_ipopt(self):
-        self.optimize_with_hotstart('IPOPT', decimal=4)
+        self.optimize_with_hotstart('IPOPT', 1E-4)
 
     def test_paropt(self):
-        self.optimize_with_hotstart('ParOpt', decimal=6)
+        self.optimize_with_hotstart('ParOpt', 1E-6)
 
     def test_conmin(self):
         opts = {'DELFUN' : 1e-10,
                 'DABFUN' : 1e-10}
-        self.optimize_with_hotstart('CONMIN', decimal=10, optOptions=opts)
+        self.optimize_with_hotstart('CONMIN', 1E-10, optOptions=opts)
 
     def test_psqp(self):
-        self.optimize_with_hotstart('PSQP', decimal=12)
+        self.optimize_with_hotstart('PSQP', 1E-12)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_hs071.py
+++ b/test/test_hs071.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 import unittest
 import numpy
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 from pyoptsparse import Optimization, OPT, History
 
 class TestHS71(unittest.TestCase):
@@ -32,7 +32,7 @@ class TestHS71(unittest.TestCase):
         fail = False
         return funcsSens, fail
 
-    def optimize(self, optName, optOptions={}, storeHistory=False, decimal=5, xScale=1.0, objScale=1.0, conScale=1.0):
+    def optimize(self, optName, tol, optOptions={}, storeHistory=False, xScale=1.0, objScale=1.0, conScale=1.0):
         # Optimization Object
         optProb = Optimization('HS071 Constraint Problem', self.objfunc)
 
@@ -58,21 +58,21 @@ class TestHS71(unittest.TestCase):
         self.fStar = 17.0140172
         self.xStar = (1.0, 4.743, 3.82115, 1.37941)
         self.lambdaStar = (0.55229366, -0.16146857)
-        assert_almost_equal(sol.objectives['obj'].value, self.fStar, decimal=decimal)
-        assert_almost_equal(sol.xStar['xvars'], self.xStar, decimal=decimal)
+        assert_allclose(sol.objectives['obj'].value, self.fStar, atol = tol, rtol = tol)
+        assert_allclose(sol.xStar['xvars'], self.xStar, atol = tol, rtol = tol)
 
         if hasattr(sol, 'lambdaStar'):
-            assert_almost_equal(sol.lambdaStar['con'], self.lambdaStar, decimal=decimal)
+            assert_allclose(sol.lambdaStar['con'], self.lambdaStar, atol = tol, rtol = tol)
 
     def test_snopt(self):
-        self.optimize('snopt')
+        self.optimize('snopt', 1E-6)
     
     def test_snopt_scaling(self):
         histFileName = 'snopt_scale_test.hst'
         objScale = 4.2
         xScale = [2,3,4,5]
         conScale = [0.6, 1.7]
-        self.optimize('snopt', objScale=objScale, xScale=xScale, conScale=conScale, storeHistory=histFileName)
+        self.optimize('snopt', 1E-6, objScale=objScale, xScale=xScale, conScale=conScale, storeHistory=histFileName)
 
         # now we retrieve the history file, and check the scale=True option is indeed
         # scaling things correctly
@@ -81,27 +81,27 @@ class TestHS71(unittest.TestCase):
         last_scaled = hist.getValues(callCounters='last', scale=True)
         x = last['xvars'][0]
         x_scaled = last_scaled['xvars'][0]
-        assert_almost_equal(x_scaled/x,xScale, decimal=12)
+        assert_allclose(x_scaled/x,xScale, atol=1E-12, rtol=1E-12)
 
     def test_slsqp(self):
-        self.optimize('slsqp')
+        self.optimize('slsqp', 1E-6)
 
     def test_nlpqlp(self):
-        self.optimize('nlpqlp')
+        self.optimize('nlpqlp', 1E-6)
 
     def test_ipopt(self):
-        self.optimize('ipopt')
+        self.optimize('ipopt', 1E-6)
 
     def test_conmin(self):
         opts = {'DELFUN' : 1e-9,
                 'DABFUN' : 1e-9}
-        self.optimize('conmin', optOptions=opts, decimal=2)
+        self.optimize('conmin', 1E-2, optOptions=opts)
 
     def test_psqp(self):
-        self.optimize('psqp')
+        self.optimize('psqp', 1E-6)
 
     def test_paropt(self):
-        self.optimize('paropt')
+        self.optimize('paropt', 1E-6)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_hs071.py
+++ b/test/test_hs071.py
@@ -6,38 +6,35 @@ import unittest
 import numpy
 from pyoptsparse import Optimization, OPT
 
-
-def objfunc(xdict):
-    x = xdict['xvars']
-    funcs = {}
-    funcs['obj'] = x[0] * x[3] * (x[0] + x[1] + x[2]) + x[2]
-    funcs['con'] = [x[0] * x[1] * x[2] * x[3],
-                   x[0]*x[0] + x[1]*x[1] + x[2]*x[2] + x[3]*x[3]]
-    fail = False
-    return funcs, fail
-
-
-def sens(xdict, funcs):
-    x = xdict['xvars']
-    funcsSens = {}
-    funcsSens['obj'] = {'xvars': numpy.array(
-            [x[0] * x[3] + x[3] * (x[0] + x[1] + x[2]) ,
-             x[0] * x[3],
-             x[0] * x[3] + 1.0,
-             x[0] * (x[0] + x[1] + x[2])
-             ])}
-    jac = [[x[1]*x[2]*x[3], x[0]*x[2]*x[3], x[0]*x[1]*x[3], x[0]*x[1]*x[2]],
-           [2.0*x[0], 2.0*x[1], 2.0*x[2], 2.0*x[3]]]
-    funcsSens['con'] = {'xvars': jac}
-    fail = False
-    return funcsSens, fail
-
-
 class TestHS71(unittest.TestCase):
+    def objfunc(self, xdict):
+        x = xdict['xvars']
+        funcs = {}
+        funcs['obj'] = x[0] * x[3] * (x[0] + x[1] + x[2]) + x[2]
+        funcs['con'] = [x[0] * x[1] * x[2] * x[3],
+                    x[0]*x[0] + x[1]*x[1] + x[2]*x[2] + x[3]*x[3]]
+        fail = False
+        return funcs, fail
+
+
+    def sens(self, xdict, funcs):
+        x = xdict['xvars']
+        funcsSens = {}
+        funcsSens['obj'] = {'xvars': numpy.array(
+                [x[0] * x[3] + x[3] * (x[0] + x[1] + x[2]) ,
+                x[0] * x[3],
+                x[0] * x[3] + 1.0,
+                x[0] * (x[0] + x[1] + x[2])
+                ])}
+        jac = [[x[1]*x[2]*x[3], x[0]*x[2]*x[3], x[0]*x[1]*x[3], x[0]*x[1]*x[2]],
+            [2.0*x[0], 2.0*x[1], 2.0*x[2], 2.0*x[3]]]
+        funcsSens['con'] = {'xvars': jac}
+        fail = False
+        return funcsSens, fail
 
     def optimize(self, optName, optOptions={}, storeHistory=False, places=5, xScale=1.0, objScale=1.0, conScale=1.0):
         # Optimization Object
-        optProb = Optimization('HS071 Constraint Problem', objfunc)
+        optProb = Optimization('HS071 Constraint Problem', self.objfunc)
 
         # Design Variables
         x0 = [1.0, 5.0, 5.0, 1.0]
@@ -55,25 +52,26 @@ class TestHS71(unittest.TestCase):
         except:
             raise unittest.SkipTest('Optimizer not available:', optName)
 
-        sol = opt(optProb, sens=sens)
+        sol = opt(optProb, sens=self.sens)
 
         # Check Solution
-        self.assertAlmostEqual(sol.objectives['obj'].value, 17.0140172, places=places)
-
-        self.assertAlmostEqual(sol.xStar['xvars'][0], 1.0, places=places)
-        self.assertAlmostEqual(sol.xStar['xvars'][1], 4.743, places=places)
-        self.assertAlmostEqual(sol.xStar['xvars'][2], 3.82115, places=places)
-        self.assertAlmostEqual(sol.xStar['xvars'][3], 1.37941, places=places)
+        self.fStar = 17.0140172
+        self.xStar = (1.0, 4.743, 3.82115, 1.37941)
+        self.lambdaStar = (0.55229366, -0.16146857)
+        self.assertAlmostEqual(sol.objectives['obj'].value, self.fStar, places=places)
+        for i in range(4):
+            self.assertAlmostEqual(sol.xStar['xvars'][i], self.xStar[i], places=places)
 
         if hasattr(sol, 'lambdaStar'):
-            self.assertAlmostEqual(sol.lambdaStar['con'][0], 0.55229366, places=places)
-            self.assertAlmostEqual(sol.lambdaStar['con'][1], -0.16146857, places=places)
+            for i in range(2):
+                self.assertAlmostEqual(sol.lambdaStar['con'][i], self.lambdaStar[i], places=places)
 
     def test_snopt(self):
         self.optimize('snopt')
     
     def test_snopt_scaling(self):
         self.optimize('snopt', objScale=4.2, xScale=[2,3,4,5], conScale=[0.6, 1.7])
+        
 
     def test_slsqp(self):
         self.optimize('slsqp')

--- a/test/test_hs071.py
+++ b/test/test_hs071.py
@@ -32,7 +32,7 @@ class TestHS71(unittest.TestCase):
         fail = False
         return funcsSens, fail
 
-    def optimize(self, optName, optOptions={}, storeHistory=False, places=5, xScale=1.0, objScale=1.0, conScale=1.0):
+    def optimize(self, optName, optOptions={}, storeHistory=False, decimal=5, xScale=1.0, objScale=1.0, conScale=1.0):
         # Optimization Object
         optProb = Optimization('HS071 Constraint Problem', self.objfunc)
 
@@ -58,13 +58,11 @@ class TestHS71(unittest.TestCase):
         self.fStar = 17.0140172
         self.xStar = (1.0, 4.743, 3.82115, 1.37941)
         self.lambdaStar = (0.55229366, -0.16146857)
-        self.assertAlmostEqual(sol.objectives['obj'].value, self.fStar, places=places)
-        for i in range(4):
-            self.assertAlmostEqual(sol.xStar['xvars'][i], self.xStar[i], places=places)
+        assert_almost_equal(sol.objectives['obj'].value, self.fStar, decimal=decimal)
+        assert_almost_equal(sol.xStar['xvars'], self.xStar, decimal=decimal)
 
         if hasattr(sol, 'lambdaStar'):
-            for i in range(2):
-                self.assertAlmostEqual(sol.lambdaStar['con'][i], self.lambdaStar[i], places=places)
+            assert_almost_equal(sol.lambdaStar['con'], self.lambdaStar, decimal=decimal)
 
     def test_snopt(self):
         self.optimize('snopt')
@@ -97,7 +95,7 @@ class TestHS71(unittest.TestCase):
     def test_conmin(self):
         opts = {'DELFUN' : 1e-9,
                 'DABFUN' : 1e-9}
-        self.optimize('conmin', optOptions=opts, places=2)
+        self.optimize('conmin', optOptions=opts, decimal=2)
 
     def test_psqp(self):
         self.optimize('psqp')

--- a/test/test_hs071.py
+++ b/test/test_hs071.py
@@ -2,9 +2,9 @@
 from __future__ import print_function
 
 import unittest
-
 import numpy
-from pyoptsparse import Optimization, OPT
+from numpy.testing import assert_almost_equal
+from pyoptsparse import Optimization, OPT, History
 
 class TestHS71(unittest.TestCase):
     def objfunc(self, xdict):
@@ -52,7 +52,7 @@ class TestHS71(unittest.TestCase):
         except:
             raise unittest.SkipTest('Optimizer not available:', optName)
 
-        sol = opt(optProb, sens=self.sens)
+        sol = opt(optProb, sens=self.sens, storeHistory=storeHistory)
 
         # Check Solution
         self.fStar = 17.0140172
@@ -70,8 +70,20 @@ class TestHS71(unittest.TestCase):
         self.optimize('snopt')
     
     def test_snopt_scaling(self):
-        self.optimize('snopt', objScale=4.2, xScale=[2,3,4,5], conScale=[0.6, 1.7])
-        
+        histFileName = 'snopt_scale_test.hst'
+        objScale = 4.2
+        xScale = [2,3,4,5]
+        conScale = [0.6, 1.7]
+        self.optimize('snopt', objScale=objScale, xScale=xScale, conScale=conScale, storeHistory=histFileName)
+
+        # now we retrieve the history file, and check the scale=True option is indeed
+        # scaling things correctly
+        hist = History(histFileName, flag='r')
+        last = hist.getValues(callCounters='last', scale=False)
+        last_scaled = hist.getValues(callCounters='last', scale=True)
+        x = last['xvars'][0]
+        x_scaled = last_scaled['xvars'][0]
+        assert_almost_equal(x_scaled/x,xScale, decimal=12)
 
     def test_slsqp(self):
         self.optimize('slsqp')

--- a/test/test_large_sparse.py
+++ b/test/test_large_sparse.py
@@ -1,15 +1,15 @@
 """
 This example is taken from the OpenOpt Examples website.
 
-http://trac.openopt.org/openopt/browser/PythonPackages/FuncDesigner/FuncDesigner/examples/nlpSparse.py
+https://github.com/PythonCharmers/OOSuite/blob/master/FuncDesigner/FuncDesigner/examples/nlpSparse.py
 
 Only testing with SNOPT, which supports sparse formats.
 """
 from __future__ import print_function
 
 import unittest
-
 import numpy
+from numpy.testing import assert_almost_equal
 from numpy import arange
 from scipy import sparse
 
@@ -44,7 +44,7 @@ def sens(xdict, funcs):
 
 class TestLargeSparse(unittest.TestCase):
 
-    def optimize(self, optName, optOptions={}, storeHistory=False, places=5):
+    def optimize(self, optName, optOptions={}, storeHistory=False, decimal=5):
         # Optimization Object
         optProb = Optimization('large and sparse', objfunc)
 
@@ -72,9 +72,9 @@ class TestLargeSparse(unittest.TestCase):
         sol = opt(optProb, sens=sens)
 
         # Check Solution
-        self.assertAlmostEqual(sol.objectives['obj'].value, 10.0, places=places)
+        assert_almost_equal(sol.objectives['obj'].value, 10.0, decimal=decimal)
 
-        self.assertAlmostEqual(sol.variables['x'][0].value, 2.0, places=places)
+        assert_almost_equal(sol.variables['x'][0].value, 2.0, decimal=decimal)
 
     def test_snopt(self):
         self.optimize('snopt')

--- a/test/test_large_sparse.py
+++ b/test/test_large_sparse.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 
 import unittest
 import numpy
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 from numpy import arange
 from scipy import sparse
 
@@ -44,7 +44,7 @@ def sens(xdict, funcs):
 
 class TestLargeSparse(unittest.TestCase):
 
-    def optimize(self, optName, optOptions={}, storeHistory=False, decimal=5):
+    def optimize(self, optName, tol, optOptions={}, storeHistory=False):
         # Optimization Object
         optProb = Optimization('large and sparse', objfunc)
 
@@ -72,12 +72,12 @@ class TestLargeSparse(unittest.TestCase):
         sol = opt(optProb, sens=sens)
 
         # Check Solution
-        assert_almost_equal(sol.objectives['obj'].value, 10.0, decimal=decimal)
+        assert_allclose(sol.objectives['obj'].value, 10.0, atol = tol, rtol = tol)
 
-        assert_almost_equal(sol.variables['x'][0].value, 2.0, decimal=decimal)
+        assert_allclose(sol.variables['x'][0].value, 2.0, atol = tol, rtol = tol)
 
     def test_snopt(self):
-        self.optimize('snopt')
+        self.optimize('snopt', tol=1E-5)
 
 
 if __name__ == "__main__":

--- a/test/test_nsga2_multi_objective.py
+++ b/test/test_nsga2_multi_objective.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 
 import unittest
-
+from numpy.testing import assert_almost_equal
 from pyoptsparse import Optimization, NSGA2
 
 
@@ -44,9 +44,9 @@ class TestNSGA2(unittest.TestCase):
         sol = opt(optProb)
 
         # Check Solution
-        self.assertAlmostEqual(sol.variables['x'][0].value, 1.0, places=2)
+        assert_almost_equal(sol.variables['x'][0].value, 1.0, decimal=2)
 
-        self.assertAlmostEqual(sol.variables['y'][0].value, 1.0, places=2)
+        assert_almost_equal(sol.variables['y'][0].value, 1.0, decimal=2)
 
 
 if __name__ == "__main__":

--- a/test/test_nsga2_multi_objective.py
+++ b/test/test_nsga2_multi_objective.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 
 import unittest
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 from pyoptsparse import Optimization, NSGA2
 
 
@@ -44,9 +44,10 @@ class TestNSGA2(unittest.TestCase):
         sol = opt(optProb)
 
         # Check Solution
-        assert_almost_equal(sol.variables['x'][0].value, 1.0, decimal=2)
+        tol = 1E-2
+        assert_allclose(sol.variables['x'][0].value, 1.0, atol=tol, rtol=tol)
 
-        assert_almost_equal(sol.variables['y'][0].value, 1.0, decimal=2)
+        assert_allclose(sol.variables['y'][0].value, 1.0, atol=tol, rtol=tol)
 
 
 if __name__ == "__main__":

--- a/test/test_snopt_bugfix.py
+++ b/test/test_snopt_bugfix.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import unittest
 
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 from pyoptsparse import Optimization, SNOPT
 
 
@@ -98,8 +98,9 @@ class TestSNOPTBug(unittest.TestCase):
         sol = opt(optProb, sens=sens)
 
         # Check Solution 7.166667, -7.833334
-        assert_almost_equal(sol.variables['x'][0].value, 7.166667, decimal=6)
-        assert_almost_equal(sol.variables['y'][0].value, -7.833333, decimal=6)
+        tol = 1E-6
+        assert_allclose(sol.variables['x'][0].value, 7.166667, atol=tol, rtol=tol)
+        assert_allclose(sol.variables['y'][0].value, -7.833333, atol=tol, rtol=tol)
 
     def test_opt_bug1(self):
         # Due to a new feature, there is a TypeError when you optimize a model without a constraint.

--- a/test/test_snopt_bugfix.py
+++ b/test/test_snopt_bugfix.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import unittest
 
 import numpy as np
-
+from numpy.testing import assert_almost_equal
 from pyoptsparse import Optimization, SNOPT
 
 
@@ -58,8 +58,6 @@ def sens(xdict, funcs):
 
     funcsSens['obj', 'x'] = 2.0*x - 6.0 + y
     funcsSens['obj', 'y'] = 2.0*y + 8.0 + x
-    #funcsSens['con', 'x'] = -1.0
-    #funcsSens['con', 'y'] = 1.0
 
     fail = False
     return funcsSens, fail
@@ -100,8 +98,8 @@ class TestSNOPTBug(unittest.TestCase):
         sol = opt(optProb, sens=sens)
 
         # Check Solution 7.166667, -7.833334
-        self.assertAlmostEqual(sol.variables['x'][0].value, 7.166667, places=6)
-        self.assertAlmostEqual(sol.variables['y'][0].value, -7.833333, places=6)
+        assert_almost_equal(sol.variables['x'][0].value, 7.166667, decimal=6)
+        assert_almost_equal(sol.variables['y'][0].value, -7.833333, decimal=6)
 
     def test_opt_bug1(self):
         # Due to a new feature, there is a TypeError when you optimize a model without a constraint.

--- a/test/test_tp109.py
+++ b/test/test_tp109.py
@@ -30,7 +30,7 @@ import unittest
 
 import numpy
 from numpy import sin, cos
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 from pyoptsparse import Optimization, OPT
 
 USE_LINEAR = True
@@ -67,7 +67,7 @@ def objfunc(xdict):
 
 class TestTP109(unittest.TestCase):
 
-    def optimize(self, optName, optOptions={}, decimal=2):
+    def optimize(self, optName, tol, optOptions={}):
         # Optimization Object
         optProb = Optimization('TP109 Constraint Problem', objfunc)
 
@@ -110,13 +110,13 @@ class TestTP109(unittest.TestCase):
         sol = opt(optProb, sens='CS')
 
         # Check Solution
-        assert_almost_equal(sol.objectives['obj'].value, 0.536206927538e+04, decimal=decimal)
+        assert_allclose(sol.objectives['obj'].value, 0.536206927538e+04, atol=tol, rtol=tol)
 
     def test_snopt(self):
-        self.optimize('snopt')
+        self.optimize('snopt', 1E-7)
 
     def test_slsqp(self):
-        self.optimize('slsqp')
+        self.optimize('slsqp', 1E-7)
 
     def test_autorefine(self):
         # Optimization Object
@@ -168,7 +168,7 @@ class TestTP109(unittest.TestCase):
         sol2 = opt2(sol1)
 
         # Check Solution
-        assert_almost_equal(sol2.objectives['obj'].value, 0.536206927538e+04, decimal=2)
+        assert_allclose(sol2.objectives['obj'].value, 0.536206927538e+04, atol=1E-2, rtol=1E-2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_tp109.py
+++ b/test/test_tp109.py
@@ -30,7 +30,7 @@ import unittest
 
 import numpy
 from numpy import sin, cos
-
+from numpy.testing import assert_almost_equal
 from pyoptsparse import Optimization, OPT
 
 USE_LINEAR = True
@@ -67,7 +67,7 @@ def objfunc(xdict):
 
 class TestTP109(unittest.TestCase):
 
-    def optimize(self, optName, optOptions={}, places=2):
+    def optimize(self, optName, optOptions={}, decimal=2):
         # Optimization Object
         optProb = Optimization('TP109 Constraint Problem', objfunc)
 
@@ -110,7 +110,7 @@ class TestTP109(unittest.TestCase):
         sol = opt(optProb, sens='CS')
 
         # Check Solution
-        self.assertAlmostEqual(sol.objectives['obj'].value, 0.536206927538e+04, places=places)
+        assert_almost_equal(sol.objectives['obj'].value, 0.536206927538e+04, decimal=decimal)
 
     def test_snopt(self):
         self.optimize('snopt')
@@ -168,7 +168,7 @@ class TestTP109(unittest.TestCase):
         sol2 = opt2(sol1)
 
         # Check Solution
-        self.assertAlmostEqual(sol2.objectives['obj'].value, 0.536206927538e+04, places=2)
+        assert_almost_equal(sol2.objectives['obj'].value, 0.536206927538e+04, decimal=2)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Purpose
There was a bug in `getValues()` that caused the numpy arrays returned to be inconsistent in shape. This PR removes the messy logic, and simply uses `numpy.stack` to make sure the shapes are consistent. 

This PR also refactored some of the other tests. `assert_almost_equal` from numpy is also used instead of `self.assertAlmostEqual` in Python.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Bugfix (non-breaking change which fixes an issue)

## Testing
This issue came up with `names=Hessian`, which is a matrix. When stacked along multiple callCounters, the previous logic fails to return a 3-D array with the correct shape. I have now added tests in `test_hs015.py` to check this.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
