### PR TITLE
Ipopt informs

### DIFF
--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -30,7 +30,7 @@ except ImportError:
 # standard Python modules
 # =============================================================================
 import copy
-import time, datetime
+import time
 # =============================================================================
 # External Python modules
 # =============================================================================
@@ -362,8 +362,26 @@ class IPOPT(Optimizer):
             # 'warm_start_target_mu' : [float, 0.0]
         }
 
-        informs = { # Don't have any of these yet either..
-            }
+        informs = {
+            0: 'Solve Succeeded',
+            1: 'Solved To Acceptable Level',
+            2: 'Infeasible Problem Detected',
+            3: 'Search Direction Becomes Too Small',
+            4: 'Diverging Iterates',
+            5: 'User Requested Stop',
+            6: 'Feasible Point Found',
+            -1: 'Maximum Iterations Exceeded',
+            -2: 'Restoration Failed',
+            -3: 'Error In Step Computation',
+            -4: 'Maximum CpuTime Exceeded',
+            -10: 'Not Enough Degrees Of Freedom',
+            -11: 'Invalid Problem Definition',
+            -12: 'Invalid Option',
+            -13: 'Invalid Number Detected',
+            -100: 'Unrecoverable Exception',
+            -101: 'NonIpopt Exception Thrown',
+            -102: 'Insufficient Memory',
+            -199: 'Internal Error'}
 
         if pyipoptcore is None:
             raise Error('There was an error importing the compiled \
@@ -522,15 +540,12 @@ class IPOPT(Optimizer):
             optTime = time.time()-timeA
 
             if self.storeHistory:
-                self.metadata['endTime'] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                self.metadata['optTime'] = optTime
-                self.hist.writeData('metadata',self.metadata)
                 self.hist.close()
 
             # Store Results
             sol_inform = {}
-            # sol_inform['value'] = inform
-            # sol_inform['text'] = self.informs[inform[0]]
+            sol_inform['value'] = status
+            sol_inform['text'] = self.informs[status]
 
             # Create the optimization solution
             sol = self._createSolution(optTime, sol_inform, obj, x)

--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -30,7 +30,7 @@ except ImportError:
 # standard Python modules
 # =============================================================================
 import copy
-import time
+import time, datetime
 # =============================================================================
 # External Python modules
 # =============================================================================
@@ -540,6 +540,9 @@ class IPOPT(Optimizer):
             optTime = time.time()-timeA
 
             if self.storeHistory:
+                self.metadata['endTime'] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                self.metadata['optTime'] = optTime
+                self.hist.writeData('metadata',self.metadata)
                 self.hist.close()
 
             # Store Results


### PR DESCRIPTION
## Purpose

The current version of pyIPOPT.py was not returning the return code from IPOPT.
The file has been updated to handle the return codes as given in https://github.com/coin-or/Ipopt/blob/master/src/Interfaces/IpReturnCodes_inc.h

Resolves: #90 

This is a fix for master but the same changes apply to v1.2 (for those people without the latest SNOPT).  They are available on branch ipopt_informs_v1_2 on my fork. (I don't seem to be able to submit a PR against a fork).

## Type of change

- Bugfix (non-breaking change which fixes an issue)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

I have tested this fix locally on my system and it works as expected.  I have added tests of the inform value to IPOPT tests in the code.  All that is needed is to test that `solInform` contains the appropriate number and message.

## Checklist

- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
