### PR TITLE
Specified output filenames for each test

### DIFF
--- a/test/test_hs015.py
+++ b/test/test_hs015.py
@@ -100,7 +100,7 @@ class TestHS15(unittest.TestCase):
         try:
             assert_allclose(sol.objectives['obj'].value, self.fStar1, atol = tol, rtol = tol)
             assert_allclose(dv['xvars'], self.xStar1, atol = tol, rtol = tol)
-        except:
+        except AssertionError:
             assert_allclose(sol.objectives['obj'].value, self.fStar2, atol = tol, rtol = tol)
             assert_allclose(dv['xvars'], self.xStar2, atol = tol, rtol = tol)
 
@@ -160,7 +160,7 @@ class TestHS15(unittest.TestCase):
         In this process, it will check various combinations of storeHistory and hotStart filenames.
         It will also call `check_hist_file` after the first optimization.
         """
-        self.optimize(optName,tol,storeHistory=True,optOptions=optOptions, )
+        self.optimize(optName,tol,storeHistory=True,optOptions=optOptions)
         self.assertGreater(self.nf,0)
         self.assertGreater(self.ng,0)
         self.check_hist_file(optName, tol)
@@ -171,19 +171,24 @@ class TestHS15(unittest.TestCase):
         self.assertEqual(self.nf,0)
         self.assertEqual(self.ng,0)
         # another test with hotstart, this time with storeHistory = hotStart
-        self.optimize(optName,tol,storeHistory=True,hotStart=self.histFileName)
+        self.optimize(optName,tol,storeHistory=True,hotStart=self.histFileName, optOptions=optOptions)
         # we should have zero actual function/gradient evaluations
         self.assertEqual(self.nf,0)
         self.assertEqual(self.ng,0)
         # final test with hotstart, this time with a different storeHistory
-        self.optimize(optName,tol,storeHistory='{}_new_hotstart.hst'.format(optName),hotStart=self.histFileName)
+        self.optimize(optName,tol,storeHistory='{}_new_hotstart.hst'.format(optName),hotStart=self.histFileName, optOptions=optOptions)
         # we should have zero actual function/gradient evaluations
         self.assertEqual(self.nf,0)
         self.assertEqual(self.ng,0)
 
     def test_snopt(self):
+        test_name = 'hs015_SNOPT'
         store_vars = ['step','merit','feasibility','optimality','penalty','Hessian','condZHZ','slack','lambda']
-        optOptions = {'Save major iteration variables': store_vars}
+        optOptions = {
+            'Save major iteration variables': store_vars,
+            'Print file': '{}.out'.format(test_name),
+            'Summary file': '{}_summary.out'.format(test_name),
+        }
         self.optimize_with_hotstart('SNOPT', 1E-12, optOptions=optOptions)
 
         hist = History(self.histFileName, flag='r')
@@ -199,24 +204,32 @@ class TestHS15(unittest.TestCase):
         self.assertEqual(data['lambda'].shape,(1,2))
 
     def test_slsqp(self):
-        self.optimize_with_hotstart('SLSQP', 1E-8)
+        optOptions = {'IFILE': 'hs015_SLSQP.out'}
+        self.optimize_with_hotstart('SLSQP', 1E-8, optOptions=optOptions)
 
     def test_nlpqlp(self):
-        self.optimize_with_hotstart('NLPQLP', 1E-12)
+        optOptions = {'iFile': 'hs015_NLPQLP.out'}
+        self.optimize_with_hotstart('NLPQLP', 1E-12, optOptions=optOptions)
 
     def test_ipopt(self):
-        self.optimize_with_hotstart('IPOPT', 1E-4)
+        optOptions = {'output_file': 'hs015_IPOPT.out'}
+        self.optimize_with_hotstart('IPOPT', 1E-4, optOptions=optOptions)
 
     def test_paropt(self):
-        self.optimize_with_hotstart('ParOpt', 1E-6)
+        optOptions = {'filename': 'hs015_ParOpt.out'}
+        self.optimize_with_hotstart('ParOpt', 1E-6, optOptions=optOptions)
 
     def test_conmin(self):
-        opts = {'DELFUN' : 1e-10,
-                'DABFUN' : 1e-10}
-        self.optimize_with_hotstart('CONMIN', 1E-10, optOptions=opts)
+        optOptions = {
+            'DELFUN' : 1e-10,
+            'DABFUN' : 1e-10,
+            'IFILE' : 'hs015_CONMIN.out',
+        }
+        self.optimize_with_hotstart('CONMIN', 1E-10, optOptions=optOptions)
 
     def test_psqp(self):
-        self.optimize_with_hotstart('PSQP', 1E-12)
+        optOptions = {'IFILE': 'hs015_PSQP.out'}
+        self.optimize_with_hotstart('PSQP', 1E-12, optOptions=optOptions)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_large_sparse.py
+++ b/test/test_large_sparse.py
@@ -76,7 +76,12 @@ class TestLargeSparse(unittest.TestCase):
         assert_allclose(sol.variables['x'][0].value, 2.0, atol = tol, rtol = tol)
 
     def test_snopt(self):
-        self.optimize('snopt', tol=1E-5)
+        test_name = 'large_sparse_SNOPT'
+        optOptions = {
+            'Print file': '{}.out'.format(test_name),
+            'Summary file': '{}_summary.out'.format(test_name),
+        }
+        self.optimize('snopt', tol=1E-5, optOptions=optOptions)
 
 
 if __name__ == "__main__":

--- a/test/test_optProb.py
+++ b/test/test_optProb.py
@@ -86,7 +86,7 @@ class TestOptProb(unittest.TestCase):
         # run optimization
         # we don't care about outputs, but this performs optimizer-specific re-ordering
         # of constraints so we need this to test mappings
-        opt = OPT('slsqp')
+        opt = OPT('slsqp', options={'IFILE': 'optProb_SLSQP.out'})
         opt(self.optProb, 'FD')
 
     def test_setDV_getDV(self):

--- a/test/test_snopt_bugfix.py
+++ b/test/test_snopt_bugfix.py
@@ -86,11 +86,16 @@ class TestSNOPTBug(unittest.TestCase):
 
         # Check optimization problem:
         print(optProb)
-
+        test_name = 'bugfix_SNOPT_test_opt'
+        optOptions = {
+            'Major feasibility tolerance' : 1e-1,
+            'Print file': '{}.out'.format(test_name),
+            'Summary file': '{}_summary.out'.format(test_name),
+        }
 
         # Optimizer
         try:
-            opt = SNOPT(optOptions = {'Major feasibility tolerance' : 1e-1})
+            opt = SNOPT(options=optOptions)
         except:
             raise unittest.SkipTest('Optimizer not available: SNOPT')
 
@@ -113,9 +118,16 @@ class TestSNOPTBug(unittest.TestCase):
         # Objective
         optProb.addObj('obj')
 
+        test_name = 'bugfix_SNOPT_bug1'
+        optOptions = {
+            'Major feasibility tolerance' : 1e-1,
+            'Print file': '{}.out'.format(test_name),
+            'Summary file': '{}_summary.out'.format(test_name),
+        }
+
         # Optimizer
         try:
-            opt = SNOPT(optOptions = {'Major feasibility tolerance' : 1e-1})
+            opt = SNOPT(options=optOptions)
         except:
             raise unittest.SkipTest('Optimizer not available: SNOPT')
 
@@ -148,9 +160,16 @@ class TestSNOPTBug(unittest.TestCase):
         # Check optimization problem:
         print(optProb)
 
+        test_name = 'bugfix_SNOPT_bug_print_2con'
+        optOptions = {
+            'Major feasibility tolerance' : 1e-1,
+            'Print file': '{}.out'.format(test_name),
+            'Summary file': '{}_summary.out'.format(test_name),
+        }
+
         # Optimizer
         try:
-            opt = SNOPT(optOptions = {'Major feasibility tolerance' : 1e-1})
+            opt = SNOPT(options=optOptions)
         except:
             raise unittest.SkipTest('Optimizer not available: SNOPT')
 

--- a/test/test_snopt_user_termination.py
+++ b/test/test_snopt_user_termination.py
@@ -73,8 +73,13 @@ class TestUserTerminationStatus(unittest.TestCase):
 
         optProb.addConGroup('con', 1, lower=-15.0, upper=-15.0, wrt=['x', 'y'], linear=True, jac=con_jac)
 
+        test_name = 'SNOPT_user_termination_obj'
+        optOptions = {
+            'Print file': '{}.out'.format(test_name),
+            'Summary file': '{}_summary.out'.format(test_name),
+        }
         try:
-            opt = SNOPT()
+            opt = SNOPT(options=optOptions)
         except:
             raise unittest.SkipTest('Optimizer not available: SNOPT')
 
@@ -97,8 +102,13 @@ class TestUserTerminationStatus(unittest.TestCase):
 
         optProb.addConGroup('con', 1, lower=-15.0, upper=-15.0, wrt=['x', 'y'], linear=True, jac=con_jac)
 
+        test_name = 'SNOPT_user_termination_sens'
+        optOptions = {
+            'Print file': '{}.out'.format(test_name),
+            'Summary file': '{}_summary.out'.format(test_name),
+        }
         try:
-            opt = SNOPT()
+            opt = SNOPT(options=optOptions)
         except:
             raise unittest.SkipTest('Optimizer not available: SNOPT')
 


### PR DESCRIPTION
## Purpose
By default, each optimizer has a default output file name.
I updated the tests to specify a unique filename for each test. That way, when tests are run concurrently with `testflo`, there are no file IO clashes.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
