### PR TITLE
Fixed bug where getValues() tries to retrieve linear constraint values

### DIFF
--- a/pyoptsparse/pyOpt_history.py
+++ b/pyoptsparse/pyOpt_history.py
@@ -436,7 +436,9 @@ class History(object):
         """
         conDict = {}
         for con in self.conNames:
-            conDict[con] = d['funcs'][con]
+            # linear constraints are not stored in funcs
+            if not self.optProb.constraints[con].linear:
+                conDict[con] = d['funcs'][con]
         objDict = {}
         for obj in self.objNames:
             objDict[obj] = d['funcs'][obj]

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -165,15 +165,10 @@ class Optimizer(object):
             self.storeHistory = True
 
             if hotStart is not None:
-                varInfo = self.hotStart.read('varInfo')
-                conInfo = self.hotStart.read('conInfo')
-                objInfo = self.hotStart.read('objInfo')
-                if varInfo is not None:
-                    self.hist.writeData('varInfo', varInfo)
-                if conInfo is not None:
-                    self.hist.writeData('conInfo', conInfo)
-                if objInfo is not None:
-                    self.hist.writeData('objInfo', objInfo)
+                for key in ['varInfo', 'conInfo', 'objInfo', 'optProb']:
+                    val = self.hotStart.read(key)
+                    if val is not None:
+                        self.hist.writeData(key, val)
                 self._setMetadata()
                 self.hist.writeData('metadata',self.metadata)
 


### PR DESCRIPTION
## Purpose
`getValues` tries to loop over all the `conNames`, which contains all the linear constraints too. So, when constructing the dictionary of values, it then tries to read those linear constraint values from `funcs`, which are of course not stored there. So I've modified it to just only read from `funcs` if the constraint is nonlinear.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Bugfix (non-breaking change which fixes an issue)

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
