### PR TITLE
Minor format fix

### DIFF
--- a/pyoptsparse/pyALPSO/alpso_ext.py
+++ b/pyoptsparse/pyALPSO/alpso_ext.py
@@ -71,7 +71,7 @@ def alpso(dimensions, constraints, neqcons, xtype, x0, xmin, xmax, swarmsize, nh
             x0 = np.array(x0)
         elif not isinstance(x0, np.ndarray):
             pyOptSparseWarning(
-                ("Initial x must be either list or numpy.array, " "all initial positions randomly generated")
+                ("Initial x must be either list or numpy.array, all initial positions randomly generated")
             )
 
     #

--- a/pyoptsparse/pyNLPQLP/pyNLPQLP.py
+++ b/pyoptsparse/pyNLPQLP/pyNLPQLP.py
@@ -64,20 +64,20 @@ class NLPQLP(Optimizer):
             0: "The optimality conditions are satisfied.",
             1: " The algorithm has been stopped after MAXIT iterations.",
             2: " The algorithm computed an uphill search direction.",
-            3: " Underflow occurred when determining a new approximation matrix" "for the Hessian of the Lagrangian.",
+            3: " Underflow occurred when determining a new approximation matrix for the Hessian of the Lagrangian.",
             4: "The line search could not be terminated successfully.",
-            5: "Length of a working array is too short." " More detailed error information is obtained with IPRINT>0",
+            5: "Length of a working array is too short. More detailed error information is obtained with IPRINT>0",
             6: "There are false dimensions, for example M>MMAX, N>=NMAX, or MNN2<>M+N+N+2.",
             7: "The search direction is close to zero, but the current iterate is still infeasible.",
             8: "The starting point violates a lower or upper bound.",
-            9: "Wrong input parameter, i.e., MODE, LDL decomposition in D and C" " (in case of MODE=1), IPRINT, IOUT",
+            9: "Wrong input parameter, i.e., MODE, LDL decomposition in D and C (in case of MODE=1), IPRINT, IOUT",
             10: "Internal inconsistency of the quadratic subproblem, division by zero.",
             100: "The solution of the quadratic programming subproblem has been"
             " terminated with an error message and IFAIL is set to IFQL+100,"
             " where IFQL denotes the index of an inconsistent constraint.",
         }
         if nlpqlp is None:
-            raise Error("There was an error importing the compiled " "nlpqlp module")
+            raise Error("There was an error importing the compiled nlpqlp module")
 
         Optimizer.__init__(self, name, category, defOpts, informs, *args, **kwargs)
         # NLPQLP needs jacobians in dense format

--- a/pyoptsparse/pyNOMAD/pyNOMAD.py
+++ b/pyoptsparse/pyNOMAD/pyNOMAD.py
@@ -46,7 +46,7 @@ class NOMAD(Optimizer):
         informs = {}
         self.set_options = []
         if nomad is None:
-            raise Error("There was an error importing the compiled" "nomad module")
+            raise Error("There was an error importing the compiled nomad module")
 
         Optimizer.__init__(self, name, category, defOpts, informs, *args, **kwargs)
 

--- a/pyoptsparse/pyOpt_constraint.py
+++ b/pyoptsparse/pyOpt_constraint.py
@@ -230,7 +230,7 @@ class Constraint(object):
                 try:
                     self.wrt = list(self.wrt)
                 except:  # noqa: E722
-                    raise Error("The 'wrt' argument to constraint '%s' must " "be an iterable list" % self.name)
+                    raise Error("The 'wrt' argument to constraint '%s' must be an iterable list" % self.name)
 
             # We allow 'None' to be in the list...they are null so
             # just pop them out:

--- a/pyoptsparse/pyOpt_history.py
+++ b/pyoptsparse/pyOpt_history.py
@@ -57,7 +57,7 @@ class History(object):
                 # manually close the underlying db at the end
                 self.db = OrderedDict(SqliteDict(fileName))
             else:
-                raise Error("The requested history file %s to open in " "read-only mode does not exist." % fileName)
+                raise Error("The requested history file %s to open in read-only mode does not exist." % fileName)
             self._processDB()
         else:
             raise Error("The flag argument to History must be 'r' or 'n'.")

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -1570,7 +1570,6 @@ class Optimization(object):
         for objKey in self.objectives:
             iObj = self.objectiveIdx[objKey]
             fobj_return[iObj] *= self.objectives[objKey].scale
-        # print(fobj, fobj_return)
         return fobj_return
 
     def _mapObjtoUser(self, fobj):

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -237,12 +237,12 @@ class Optimization(object):
         # Check that the nVars is > 0.
         if nVars < 1:
             raise Error(
-                "The 'nVars' argument to addVarGroup must be greater " "than or equal to 1. The bad DV is %s." % name
+                "The 'nVars' argument to addVarGroup must be greater than or equal to 1. The bad DV is %s." % name
             )
 
         # Check that the type is ok:
         if type not in ["c", "i", "d"]:
-            raise Error("Type must be one of 'c' for continuous, " "'i' for integer or 'd' for discrete.")
+            raise Error("Type must be one of 'c' for continuous, 'i' for integer or 'd' for discrete.")
 
         # ------ Process the value argument
         value = np.atleast_1d(value).real
@@ -339,10 +339,10 @@ class Optimization(object):
         if name in self.variables:
             # Check that the variables happen to be the same
             if not len(self.variables[name]) == len(varList):
-                raise Error("The supplied name '%s' for a variable group " "has already been used!" % name)
+                raise Error("The supplied name '%s' for a variable group has already been used!" % name)
             for i in range(len(varList)):
                 if not varList[i] == self.variables[name][i]:
-                    raise Error("The supplied name '%s' for a variable group " "has already been used!" % name)
+                    raise Error("The supplied name '%s' for a variable group has already been used!" % name)
             # We we got here, we know that the variables we wanted to
             # add are **EXACTLY** the same so that's cool. We'll just
             # overwrite with the varList below.
@@ -506,7 +506,7 @@ class Optimization(object):
         """
 
         if name in self.constraints:
-            raise Error("The supplied name '%s' for a constraint group " "has already been used." % name)
+            raise Error("The supplied name '%s' for a constraint group has already been used." % name)
 
         # Simply add constraint object
         self.constraints[name] = Constraint(name, nCon, linear, wrt, jac, lower, upper, scale)
@@ -1048,9 +1048,9 @@ class Optimization(object):
                 else:
                     xg[dvGroup] = x[..., istart:iend].copy()
             except IndexError:
-                raise Error("Error processing x. There " "is a mismatch in the number of variables.")
+                raise Error("Error processing x. There is a mismatch in the number of variables.")
         if imax != self.ndvs:
-            raise Error("Error processing x. There " "is a mismatch in the number of variables.")
+            raise Error("Error processing x. There is a mismatch in the number of variables.")
         return xg
 
     def processXtoVec(self, x):
@@ -1084,9 +1084,9 @@ class Optimization(object):
                 else:
                     x_array[..., istart:iend] = x[dvGroup]
             except IndexError:
-                raise Error("Error deprocessing x. There " "is a mismatch in the number of variables.")
+                raise Error("Error deprocessing x. There is a mismatch in the number of variables.")
         if imax != self.ndvs:
-            raise Error("Error deprocessing x. There is a mismatch in the" " number of variables.")
+            raise Error("Error deprocessing x. There is a mismatch in the number of variables.")
 
         return x_array
 
@@ -1113,7 +1113,7 @@ class Optimization(object):
                 try:
                     f = np.squeeze(funcs[objKey]).item()
                 except ValueError:
-                    raise Error("The objective return value, '%s' must be a " "scalar!" % objKey)
+                    raise Error("The objective return value, '%s' must be a scalar!" % objKey)
                 # Store objective for printing later
                 self.objectives[objKey].value = f
                 fobj.append(f)
@@ -1209,7 +1209,7 @@ class Optimization(object):
                 # Store constraint values for printing later
                 con.value = copy.copy(c)
             else:
-                raise Error("No constraint values were found for the " "constraint '%s'." % iCon)
+                raise Error("No constraint values were found for the constraint '%s'." % iCon)
 
         # Perform scaling on the original jacobian:
         if scaled:

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -666,7 +666,7 @@ class Optimizer(object):
                     xs.append(var.value)
 
                 else:
-                    raise Error("%s cannot handle integer or discrete " "design variables" % self.name)
+                    raise Error("%s cannot handle integer or discrete design variables" % self.name)
 
         blx = np.array(blx)
         bux = np.array(bux)
@@ -716,7 +716,7 @@ class Optimizer(object):
         nobj = len(self.optProb.objectives.keys())
         ff = []
         if nobj == 0:
-            raise Error("No objective function was supplied! One can " "be added using a call to optProb.addObj()")
+            raise Error("No objective function was supplied! One can be added using a call to optProb.addObj()")
         for objKey in self.optProb.objectives:
             ff.append(self.optProb.objectives[objKey].value)
 

--- a/pyoptsparse/pyOpt_variable.py
+++ b/pyoptsparse/pyOpt_variable.py
@@ -42,7 +42,7 @@ class Variable(object):
             self.scale = scale
         elif self.type == "d":
             if choices is None:
-                raise Error("A discrete variable requires " "to input an array of choices.")
+                raise Error("A discrete variable requires to input an array of choices.")
             self.choices = choices
             self.value = self.choices[int(value)]
             self.lower = 0

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -237,7 +237,7 @@ class SNOPT(Optimizer):
 
         # Check if we have numpy version 1.13.1. This version broke the callback in snopt.
         if np.__version__ == "1.13.1":
-            raise Error("SNOPT is not compatible with numpy 1.13.1. Please use a different" "numpy version")
+            raise Error("SNOPT is not compatible with numpy 1.13.1. Please use a different numpy version")
 
     def __call__(
         self,

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
         long_description="pyOptSparse is a Python package for formulating and solving nonlinear constrained optimization problems",
         keywords="optimization",
         license="GNU LGPL",
-        install_requires=['sqlitedict>=1.6.0', 'numpy', 'scipy', 'six>=1.13'],
+        install_requires=["sqlitedict>=1.6.0", "numpy", "scipy", "six>=1.13"],
         platforms=["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
         classifiers=[
             "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
## Purpose
This is a minor formatting fix. Due to the way things were coded before, long error messages were concatenated by just a series of strings. When I reformatted with black, it combined certain lines which were not long enough into a single line, resulting in these extra quotes. I removed them in this PR.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Code style update (formatting, renaming)