### PR TITLE
fixed setDVs bug when setting a subset of DVs

### DIFF
--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -554,9 +554,13 @@ class Optimization(object):
         """
         self.finalizeDesignVariables()
         self.finalizeConstraints()
+        x0 = self.getDVs()
+        # overwrite subset of DVs with new values
+        for dvGroup in inDVs:
+            x0[dvGroup] = inDVs[dvGroup]
         # we process dicts to arrays to perform scaling in a uniform way
         # then process back to dict
-        scaled_DV = self._mapXtoOpt_Dict(inDVs)
+        scaled_DV = self._mapXtoOpt_Dict(x0)
         for dvGroup in self.variables:
             if dvGroup in inDVs:
                 nvar = len(self.variables[dvGroup])

--- a/test/test_optProb.py
+++ b/test/test_optProb.py
@@ -96,7 +96,7 @@ class TestOptProb(unittest.TestCase):
         self.optProb.setDVs(newDV)
         outDV = self.optProb.getDVs()
         self.assert_dict_allclose(newDV, outDV)
-        
+
     def test_setDV_VarGroup(self):
         """
         Test that setDV works with a subset of VarGroups

--- a/test/test_optProb.py
+++ b/test/test_optProb.py
@@ -96,6 +96,23 @@ class TestOptProb(unittest.TestCase):
         self.optProb.setDVs(newDV)
         outDV = self.optProb.getDVs()
         self.assert_dict_allclose(newDV, outDV)
+        
+    def test_setDV_VarGroup(self):
+        """
+        Test that setDV works with a subset of VarGroups
+        """
+        self.setup_optProb(
+            nObj=1, nDV=[4, 8], nCon=[2, 3], xScale=[4, 1], objScale=[0.3], conScale=[0.1, 8], offset=[3, 7],
+        )
+        oldDV = self.optProb.getDVs()
+        # set values for only one VarGroup
+        newDV = {"x0": np.arange(4)}
+        self.optProb.setDVs(newDV)
+        outDV = self.optProb.getDVs()
+        # check x0 changed
+        assert_allclose(newDV["x0"], outDV["x0"])
+        # check x1 is the same
+        assert_allclose(oldDV["x1"], outDV["x1"])
 
     def test_mappings(self):
         """


### PR DESCRIPTION
## Purpose
This PR addresses the bug in #107 by changing setDVs to allow only a subset of DVs to be set. The full set of DVs is still used in the scaling to avoid errors in the mapping functions.

Closes #107 

## Type of change
- Bugfix (non-breaking change which fixes an issue)

## Testing
Run test_optProb.py which has the new test "test_setDV_VarGroup"

## Checklist
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation