### PR TITLE
Removing support for paropt

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ An example output from OptView is shown below.
 
 ## Optimizer Support
 pyOptSparse provides Python interfaces for a number of optimizers.
-ALPSO, CONMIN, IPOPT, NLPQLP, NSGA2, PSQP, ParOpt, SLSQP, and SNOPT are currently tested and supported.
-FSQP, AUGLAG, and NOMAD interfaces are also provided, but they are not tested nor supported.
+ALPSO, CONMIN, IPOPT, NLPQLP, NSGA2, PSQP, SLSQP, and SNOPT are currently tested and supported.
+ParOpt, FSQP, AUGLAG, and NOMAD interfaces are also provided, but they are not tested nor supported.
 
 We do not provide the source code for SNOPT and NLPQLP, due to their restrictive license requirements.
 Please contact the authors of the respective codes if you wish to obtain them.

--- a/doc/optimizers/pyparopt.rst
+++ b/doc/optimizers/pyparopt.rst
@@ -5,7 +5,10 @@ ParOpt
 ParOpt is a nonlinear interior point optimizer that is designed for large parallel design optimization problems with structured sparse constraints.
 ParOpt is open source and can be downloaded at `https://github.com/gjkennedy/paropt <https://github.com/gjkennedy/paropt>`_.
 Documentation and examples for ParOpt can be found at `https://gjkennedy.github.io/paropt/ <https://gjkennedy.github.io/paropt/>`_.
-ParOpt does not provide version tagging, but the commit ``f692160`` from October 2019 has been verified to work.
+
+.. note::
+   Unfortunately ParOpt is not officially supported by pyOptSparse at this time.
+   This is due to the fact that it is in active development with constantly changing API/functionality, but does not provide stable releases for us to test with.
 
 Installation
 ------------


### PR DESCRIPTION
## Purpose
We have decided to temporarily remove support for ParOpt, meaning we will no longer build ParOpt in our Docker images, and run pyParOpt tests within pyOptSparse.

This PR updates the documentation to reflect that change.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Documentation update