### PR TITLE
Updated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Documentation Status](https://readthedocs.com/projects/mdolab-pyoptsparse/badge/?version=latest)](https://mdolab-pyoptsparse.readthedocs-hosted.com/en/latest/?badge=latest)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-pyOptsparse is an object-oriented framework for formulating and solving nonlinear constrained optimization problems in an efficient, reusable, and portable manner.
+pyOptSparse is an object-oriented framework for formulating and solving nonlinear constrained optimization problems in an efficient, reusable, and portable manner.
 It is a fork of pyOpt that uses sparse matrices throughout the code to more efficiently handle large-scale optimization problems.
 Many optimization techniques can be used in pyOptSparse, including both gradient-based and gradient-free methods.
 A visualization tool called OptView also comes packaged with pyOptSparse, which shows the optimization history through an interactive GUI.

--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -27,7 +27,9 @@ The optimization class is created using the following call::
 
   >>> optProb = Optimization('name', objFun)
 
-The general template of the objective function is as follows::
+The general template of the objective function is as follows:
+
+.. code-block:: python
 
   def obj_fun(xdict):
     funcs = {}

--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -151,7 +151,8 @@ The ``X``'s denote which parts of the jacobian have non-zero
 values. ``pyOptSparse`` does not determine the sparsity structure of
 the jacobian automatally, it must be specified by the user during
 calls to ``addCon`` and ``addConGroup``.  By way of example, the code
-that generates the  hypothetical optimization problem is as follows::
+that generates the  hypothetical optimization problem is as follows:
+.. code-block:: python
 
   optProb.addVarGroup('varA', 3)
   optProb.addVarGroup('varB', 1)

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -5,7 +5,7 @@ Installation Instructions
 
 Requirements
 ------------
-pyOpt has the following dependencies:
+pyOptSparse has the following dependencies:
 
 * Python 2.7+ (Python 3.2+)
 * c/FORTRAN compiler (compatible with f2py)
@@ -35,7 +35,7 @@ For those not using ``conda``, a user install is needed::
 
 Notes:
     
-* You may want to uninstall any previous version of pyOpt before installing a new 
+* You may want to uninstall any previous version of pyOptSparse before installing a new
   version, as there may be conflicts.
 * Some optimizers are licensed and their sources are not included with this distribution. 
   To use them, please request their sources from the authors as indicated in the optimizer 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -35,9 +35,8 @@ For those not using ``conda``, a user install is needed::
 
 It is also possible to install by calling ``python setup.py``, but this is not recommended.
 
-Notes:
-
-* Some optimizers are licensed and their sources are not included with this distribution. 
+.. note::
+  Some optimizers are licensed and their sources are not included with this distribution. 
   To use them, please request their sources from the authors as indicated in the optimizer 
   LICENSE files, and place them in their respective source folders before installing the package.
   Refer to specific optimizer pages for additional information.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -41,7 +41,7 @@ It is also possible to install by calling ``python setup.py``, but this is not r
   LICENSE files, and place them in their respective source folders before installing the package.
   Refer to specific optimizer pages for additional information.
 
-Update or Unintall
+Update or Uninstall
 ------------------
 To update ``pyOptSparse``, first delete the ``build`` directory.
 Then update the package using ``git``.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -7,8 +7,8 @@ Requirements
 ------------
 pyOptSparse has the following dependencies:
 
-* Python 2.7+ (Python 3.2+)
-* c/FORTRAN compiler (compatible with f2py)
+* Python 2.7, 3.7 or 3.8, though other Python 3 versions will likely work
+* C/FORTRAN compiler (compatible with f2py)
 
 Please make sure these are installed and available for use.
 In order to use NSGA2 and NOMAD, SWIG (v1.3+) is also required.
@@ -33,11 +33,22 @@ For those not using ``conda``, a user install is needed::
 
   pip install -e . --user
 
+It is also possible to install by calling ``python setup.py``, but this is not recommended.
+
 Notes:
-    
-* You may want to uninstall any previous version of pyOptSparse before installing a new
-  version, as there may be conflicts.
+
 * Some optimizers are licensed and their sources are not included with this distribution. 
   To use them, please request their sources from the authors as indicated in the optimizer 
   LICENSE files, and place them in their respective source folders before installing the package.
   Refer to specific optimizer pages for additional information.
+
+Update or Unintall
+------------------
+To update ``pyOptSparse``, first delete the ``build`` directory.
+Then update the package using ``git``.
+For stability, stick to tagged releases.
+Install the package normally via ``pip``.
+
+To uninstall the package, type::
+
+  pip uninstall pyoptsparse

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -17,9 +17,9 @@ Simply comment out the corresponding lines in ``pyoptsparse/pyoptsparse/setup.py
 Python dependencies are automatically handled by ``pip``.
 
 .. note::
-  * In Windows MinGW is recommended if c/FORTRAN compilers are not available
   * In Linux, the python header files (python-dev) are also required.
-  * Compatibility on Windows 64bit has not been tested
+  * We do not support operating systems other than Linux.
+    If you want to run this on macOS or Windows, you are on your own.
 
 Installation
 ------------

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -1,40 +1,28 @@
 .. _install:
 
-Installation
-============
+Installation Instructions
+=========================
 
 Requirements
 ------------
 pyOpt has the following dependencies:
 
 * Python 2.7+ (Python 3.2+)
-* Numpy 1.16+
-* Scipy 1.3+
-* six 1.13
-* sqlitedict 1.6.0
 * c/FORTRAN compiler (compatible with f2py)
 
 Please make sure these are installed and available for use.
 In order to use NSGA2 and NOMAD, SWIG (v1.3+) is also required.
 If those optimizers are not needed, then you do not need to install SWIG.
 Simply comment out the corresponding lines in ``pyoptsparse/pyoptsparse/setup.py`` so that they are not compiled.
-
-To facilitate the installation of Python dependencies, there is a file called ``requirements.txt`` which can be used together with ``pip``.
-Simply type
-
-.. code-block:: bash
-
-  pip install -r requirements.txt
-
-In the future, we hope to make the package pip-installable so that dependencies can be managed more easily.
+Python dependencies are automatically handled by ``pip``.
 
 .. note::
   * In Windows MinGW is recommended if c/FORTRAN compilers are not available
   * In Linux, the python header files (python-dev) are also required.
   * Compatibility on Windows 64bit has not been tested
 
-Building
---------
+Installation
+------------
 The easiest and recommended way to install pyOptSparse is with ``pip``.
 First clone the repository into a location which is not on the ``$PYTHONPATH``, for example ``~/packages``.
 Then in the root ``pyoptsparse`` folder type::
@@ -45,38 +33,6 @@ For those not using ``conda``, a user install is needed::
 
   pip install -e . --user
 
-Two other ways of installing ``pyOptSparse`` are possible, both require running ``setup.py`` manually.
-The first approach is to install the package inplace, similar to the ``-e`` flag used above.
-This means that no source code is actually copied to a ``site-packages`` folder, meaning
-modifying the source code would have an immediate effect, without the need to re-install the code.
-From the root directory run::
-
-  >>> python setup.py build_ext --inplace
-
-To use pyOptSparse in this case, the user should add the path of the
-root directory to the user's ``$PYTHONPATH`` enviromental variable.
-For example, if the pyoptsparse directory is located at::
-
-  /home/<user>/packages/pyoptsparse
-
-The required line in the ``.bashrc`` file would be::
-
-  export PYTHONPATH=$PYTHONPATH:/home/<user>/packages/pyoptsparse
-
-To install the ``pyOptSparse`` package in a folder on the Python search path 
-(usually in a python site-packages or dist-packages folder) run::
-    
-  >>> python setup.py install --user
-
-This will install the package to ``~/.local`` which is typically found
-automatically by Python. If a system wide install is desired the
-command to run would be (requiring root access)::
-
-  >>> sudo python setup.py install
-
-.. warning::
-  Remember to delete the ``build`` directory first when re-building from source.
-
 Notes:
     
 * You may want to uninstall any previous version of pyOpt before installing a new 
@@ -85,19 +41,3 @@ Notes:
   To use them, please request their sources from the authors as indicated in the optimizer 
   LICENSE files, and place them in their respective source folders before installing the package.
   Refer to specific optimizer pages for additional information.
-* In Windows, if MinGW is used make sure to install for it the C, C++, and Fortran compilers and run:
-  
-  >>> python setup.py install --compiler=mingw32
-  
-* By default pyOpt will attempt to use compilers available on the system. To get a list of 
-  available compilers and their corresponding flag on a specific system use:
-  
-  >>> python setup.py build --help-fcompiler
-
-* To see a list of all available ``setup.py`` options for building run 
-  
-  >>> python setup.py build --help
-
-* In macOS, you may need to force an update of gcc using ‘brew uninstall gcc’ followed by a fresh
-  installation of gcc using ‘brew install gcc’ as ‘brew upgrade gcc’ can be insufficient if you
-  have recently updated your macOS version.


### PR DESCRIPTION
## Purpose
I removed outdated information in the installation instructions, both the `setup.py` approach for installation, as well as information on Windows install, since we do not currently support that.

I am also doing this partly to trigger a PR build for readthedocs, and testing that feature. 

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Documentation update