### PR TITLE
Added control over using mpi4py by setting environment variable PYOPTSPARSE_REQUIRE_MPI

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,12 +12,13 @@
 
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath("../"))
 
 # -- Project information -----------------------------------------------------
 
-project = 'pyOptSparse'
-copyright = '2020, MDO Lab'
+project = "pyOptSparse"
+copyright = "2020, MDO Lab"
 
 # The full version, including alpha/beta/rc tags
 # release = 'version'
@@ -35,7 +36,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "numpydoc",
     "sphinx.ext.autosummary",
-    "sphinx.ext.mathjax"
+    "sphinx.ext.mathjax",
 ]
 numpydoc_show_class_members = False
 
@@ -60,4 +61,4 @@ master_doc = "index"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -51,3 +51,19 @@ Install the package normally via ``pip``.
 To uninstall the package, type::
 
   pip uninstall pyoptsparse
+
+.. note::
+  ``pyOptSparse`` can optionally run in parallel if a suitable ``mpi4py``
+  installation exists. This will be automatically detected and
+  imported at run-time.
+
+  If you only want to run in parallel, you can
+  force ``pyOptSparse`` to do so by setting the environment variable
+  ``PYOPTSPARSE_REQUIRE_MPI`` to anyone of these values: ``['always', '1', 'true', 'yes']``
+  If a suitable ``mpi4py`` is not available, an exception will be raised and the run
+  terminated.
+
+  If you explicitly do not wish to use ``mpi4py``, set the environment variable ``PYOPTSPARSE_REQUIRE_MPI``
+  to anything other than those values. This can come in handy, for example, if your ``MPI`` installation
+  is not functioning properly, but you still need to run serial code.
+

--- a/pyoptsparse/pyOpt_MPI.py
+++ b/pyoptsparse/pyOpt_MPI.py
@@ -7,6 +7,7 @@ mpi4py. Only the method from the COMM object that are actually used in
 pyOptSparse are included here.
 """
 
+import os
 import warnings
 
 
@@ -38,13 +39,24 @@ class myMPI(object):
         self.SUM = "SUM"
         self.LOR = "OR"
 
+# Attempt to import mpi4py.
+# If PYOPTSPARSE_REQUIRE_MPI is set to a recognized positive value, attempt import
+# and raise exception on failure. If set to anything else, no import is attempted.
+if 'PYOPTSPARSE_REQUIRE_MPI' in os.environ:
+    if os.environ['PYOPTSPARSE_REQUIRE_MPI'].lower() in ['always', '1', 'true', 'yes']:
+        from mpi4py import MPI
+    else:
+        MPI = myMPI()
+# If PYOPTSPARSE_REQUIRE_MPI is unset, attempt to import mpi4py, but continue on failure
+# with a notification.
+else:
+    try:
+        from mpi4py import MPI
+    except ImportError:
+        warn = "mpi4py could not be imported. mpi4py is required to use\
+     the parallel gradient analysis and parallel objective analysis for\
+     non-gradient based optimizers. Continuing using a dummy MPI module\
+     from pyOptSparse."
+        warnings.warn(warn)
+        MPI = myMPI()
 
-try:
-    from mpi4py import MPI
-except ImportError:
-    warn = "mpi4py could not be imported. mpi4py is required to use\
- the parallel gradient analysis and parallel objective analysis for\
- non-gradient based optimizers. Continuing using a dummy MPI module\
- from pyOptSparse."
-    warnings.warn(warn)
-    MPI = myMPI()

--- a/pyoptsparse/pyOpt_MPI.py
+++ b/pyoptsparse/pyOpt_MPI.py
@@ -39,11 +39,12 @@ class myMPI(object):
         self.SUM = "SUM"
         self.LOR = "OR"
 
+
 # Attempt to import mpi4py.
 # If PYOPTSPARSE_REQUIRE_MPI is set to a recognized positive value, attempt import
 # and raise exception on failure. If set to anything else, no import is attempted.
-if 'PYOPTSPARSE_REQUIRE_MPI' in os.environ:
-    if os.environ['PYOPTSPARSE_REQUIRE_MPI'].lower() in ['always', '1', 'true', 'yes']:
+if "PYOPTSPARSE_REQUIRE_MPI" in os.environ:
+    if os.environ["PYOPTSPARSE_REQUIRE_MPI"].lower() in ["always", "1", "true", "yes"]:
         from mpi4py import MPI
     else:
         MPI = myMPI()
@@ -59,4 +60,3 @@ else:
      from pyOptSparse."
         warnings.warn(warn)
         MPI = myMPI()
-

--- a/pyoptsparse/pyParOpt/ParOpt.py
+++ b/pyoptsparse/pyParOpt/ParOpt.py
@@ -5,8 +5,8 @@ import datetime
 # Attempt to import mpi4py.
 # If PYOPTSPARSE_REQUIRE_MPI is set to a recognized positive value, attempt import
 # and raise exception on failure. If set to anything else, no import is attempted.
-if 'PYOPTSPARSE_REQUIRE_MPI' in os.environ:
-    if os.environ['PYOPTSPARSE_REQUIRE_MPI'].lower() in ['always', '1', 'true', 'yes']:
+if "PYOPTSPARSE_REQUIRE_MPI" in os.environ:
+    if os.environ["PYOPTSPARSE_REQUIRE_MPI"].lower() in ["always", "1", "true", "yes"]:
         from paropt import ParOpt as _ParOpt
         from mpi4py import MPI
     else:
@@ -19,12 +19,6 @@ else:
         from mpi4py import MPI
     except ImportError:
         _ParOpt = None
-
-# try:
-#     from paropt import ParOpt as _ParOpt
-#     from mpi4py import MPI
-# except ImportError:
-#     _ParOpt = None
 
 from ..pyOpt_optimizer import Optimizer
 from ..pyOpt_error import Error

--- a/pyoptsparse/pyParOpt/ParOpt.py
+++ b/pyoptsparse/pyParOpt/ParOpt.py
@@ -2,11 +2,29 @@ import numpy as np
 import os
 import datetime
 
-try:
-    from paropt import ParOpt as _ParOpt
-    from mpi4py import MPI
-except ImportError:
-    _ParOpt = None
+# Attempt to import mpi4py.
+# If PYOPTSPARSE_REQUIRE_MPI is set to a recognized positive value, attempt import
+# and raise exception on failure. If set to anything else, no import is attempted.
+if 'PYOPTSPARSE_REQUIRE_MPI' in os.environ:
+    if os.environ['PYOPTSPARSE_REQUIRE_MPI'].lower() in ['always', '1', 'true', 'yes']:
+        from paropt import ParOpt as _ParOpt
+        from mpi4py import MPI
+    else:
+        _ParOpt = None
+# If PYOPTSPARSE_REQUIRE_MPI is unset, attempt to import mpi4py, but continue on failure
+# with a notification.
+else:
+    try:
+        from paropt import ParOpt as _ParOpt
+        from mpi4py import MPI
+    except ImportError:
+        _ParOpt = None
+
+# try:
+#     from paropt import ParOpt as _ParOpt
+#     from mpi4py import MPI
+# except ImportError:
+#     _ParOpt = None
 
 from ..pyOpt_optimizer import Optimizer
 from ..pyOpt_error import Error

--- a/test/test_require_mpi_env_var.py
+++ b/test/test_require_mpi_env_var.py
@@ -9,6 +9,7 @@ if sys.version_info[0] == 2:
 else:
     reload_func = importlib.reload
 
+
 class TestRequireMPIEnvVar(unittest.TestCase):
     # Check how the environment variable affects importing MPI
     def test_require_mpi(self):
@@ -32,6 +33,7 @@ class TestRequireMPIEnvVar(unittest.TestCase):
         reload_func(pyoptsparse.pyOpt_MPI)
         self.assertFalse(inspect.ismodule(pyoptsparse.pyOpt_MPI.MPI))
 
+
 class TestRequireMPIEnvVarOnParOpt(unittest.TestCase):
     # Check how the environment variable affects using ParOpt
     def setUp(self):
@@ -39,7 +41,7 @@ class TestRequireMPIEnvVarOnParOpt(unittest.TestCase):
         try:
             from paropt import ParOpt as _ParOpt
         except ImportError:
-            raise unittest.SkipTest("Optimizer not available:", 'paropt')
+            raise unittest.SkipTest("Optimizer not available:", "paropt")
 
     def test_require_mpi_check_paropt(self):
         os.environ["PYOPTSPARSE_REQUIRE_MPI"] = "1"

--- a/test/test_require_mpi_env_var.py
+++ b/test/test_require_mpi_env_var.py
@@ -2,52 +2,64 @@ import importlib
 import inspect
 import unittest
 import os
+import sys
 
+if sys.version_info[0] == 2:
+    reload_func = reload
+else:
+    reload_func = importlib.reload
 
-class TestNoMPI(unittest.TestCase):
-
-    # Next 3 tests check how the environment variable affects importing MPI
+class TestRequireMPIEnvVar(unittest.TestCase):
+    # Check how the environment variable affects importing MPI
     def test_require_mpi(self):
         os.environ["PYOPTSPARSE_REQUIRE_MPI"] = "1"
         import pyoptsparse.pyOpt_MPI
 
-        importlib.reload(pyoptsparse.pyOpt_MPI)
+        reload_func(pyoptsparse.pyOpt_MPI)
         self.assertTrue(inspect.ismodule(pyoptsparse.pyOpt_MPI.MPI))
 
     def test_no_mpi_requirement_given(self):
         os.environ.pop("PYOPTSPARSE_REQUIRE_MPI", None)
         import pyoptsparse.pyOpt_MPI
 
-        importlib.reload(pyoptsparse.pyOpt_MPI)
+        reload_func(pyoptsparse.pyOpt_MPI)
         self.assertTrue(inspect.ismodule(pyoptsparse.pyOpt_MPI.MPI))
 
     def test_do_not_use_mpi(self):
         os.environ["PYOPTSPARSE_REQUIRE_MPI"] = "0"
         import pyoptsparse.pyOpt_MPI
 
-        importlib.reload(pyoptsparse.pyOpt_MPI)
+        reload_func(pyoptsparse.pyOpt_MPI)
         self.assertFalse(inspect.ismodule(pyoptsparse.pyOpt_MPI.MPI))
 
-    # Next 3 tests check how the environment variable affects using ParOpt
+class TestRequireMPIEnvVarOnParOpt(unittest.TestCase):
+    # Check how the environment variable affects using ParOpt
+    def setUp(self):
+        # Just check to see if ParOpt is installed before doing any testing
+        try:
+            from paropt import ParOpt as _ParOpt
+        except ImportError:
+            raise unittest.SkipTest("Optimizer not available:", 'paropt')
+
     def test_require_mpi_check_paropt(self):
         os.environ["PYOPTSPARSE_REQUIRE_MPI"] = "1"
         import pyoptsparse.pyParOpt.ParOpt
 
-        importlib.reload(pyoptsparse.pyParOpt.ParOpt)
+        reload_func(pyoptsparse.pyParOpt.ParOpt)
         self.assertIsNotNone(pyoptsparse.pyParOpt.ParOpt._ParOpt)
 
     def test_no_mpi_requirement_given_check_paropt(self):
         os.environ.pop("PYOPTSPARSE_REQUIRE_MPI", None)
         import pyoptsparse.pyParOpt.ParOpt
 
-        importlib.reload(pyoptsparse.pyParOpt.ParOpt)
+        reload_func(pyoptsparse.pyParOpt.ParOpt)
         self.assertIsNotNone(pyoptsparse.pyParOpt.ParOpt._ParOpt)
 
     def test_do_not_use_mpi_check_paropt(self):
         os.environ["PYOPTSPARSE_REQUIRE_MPI"] = "0"
         import pyoptsparse.pyParOpt.ParOpt
 
-        importlib.reload(pyoptsparse.pyParOpt.ParOpt)
+        reload_func(pyoptsparse.pyParOpt.ParOpt)
         self.assertIsNone(pyoptsparse.pyParOpt.ParOpt._ParOpt)
 
 

--- a/test/test_require_mpi_env_var.py
+++ b/test/test_require_mpi_env_var.py
@@ -1,0 +1,49 @@
+import importlib
+import inspect
+import unittest
+import os
+
+class TestNoMPI(unittest.TestCase):
+
+    # Next 3 tests check how the environment variable affects importing MPI
+    def test_require_mpi(self):
+        os.environ['PYOPTSPARSE_REQUIRE_MPI'] = '1'
+        import pyoptsparse.pyOpt_MPI
+        importlib.reload(pyoptsparse.pyOpt_MPI)
+        self.assertTrue(inspect.ismodule(pyoptsparse.pyOpt_MPI.MPI))
+
+    def test_no_mpi_requirement_given(self):
+        os.environ.pop('PYOPTSPARSE_REQUIRE_MPI', None)
+        import pyoptsparse.pyOpt_MPI
+        importlib.reload(pyoptsparse.pyOpt_MPI)
+        self.assertTrue(inspect.ismodule(pyoptsparse.pyOpt_MPI.MPI))
+
+    def test_do_not_use_mpi(self):
+        os.environ['PYOPTSPARSE_REQUIRE_MPI'] = '0'
+        import pyoptsparse.pyOpt_MPI
+        importlib.reload(pyoptsparse.pyOpt_MPI)
+        self.assertFalse(inspect.ismodule(pyoptsparse.pyOpt_MPI.MPI))
+
+    # Next 3 tests check how the environment variable affects using ParOpt
+    def test_require_mpi_check_paropt(self):
+        os.environ['PYOPTSPARSE_REQUIRE_MPI'] = '1'
+        import pyoptsparse.pyParOpt.ParOpt
+        importlib.reload(pyoptsparse.pyParOpt.ParOpt)
+        self.assertIsNotNone(pyoptsparse.pyParOpt.ParOpt._ParOpt)
+
+    def test_no_mpi_requirement_given_check_paropt(self):
+        os.environ.pop('PYOPTSPARSE_REQUIRE_MPI', None)
+        import pyoptsparse.pyParOpt.ParOpt
+        importlib.reload(pyoptsparse.pyParOpt.ParOpt)
+        self.assertIsNotNone(pyoptsparse.pyParOpt.ParOpt._ParOpt)
+
+    def test_do_not_use_mpi_check_paropt(self):
+        os.environ['PYOPTSPARSE_REQUIRE_MPI'] = '0'
+        import pyoptsparse.pyParOpt.ParOpt
+        importlib.reload(pyoptsparse.pyParOpt.ParOpt)
+        self.assertIsNone(pyoptsparse.pyParOpt.ParOpt._ParOpt)
+
+if __name__ == "__main__":
+    unittest.main()
+
+

--- a/test/test_require_mpi_env_var.py
+++ b/test/test_require_mpi_env_var.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 if sys.version_info[0] == 2:
-    reload_func = reload
+    reload_func = reload  # noqa: F821
 else:
     reload_func = importlib.reload
 
@@ -39,7 +39,7 @@ class TestRequireMPIEnvVarOnParOpt(unittest.TestCase):
     def setUp(self):
         # Just check to see if ParOpt is installed before doing any testing
         try:
-            from paropt import ParOpt as _ParOpt
+            from paropt import ParOpt as _ParOpt  # noqa: F401
         except ImportError:
             raise unittest.SkipTest("Optimizer not available:", "paropt")
 

--- a/test/test_require_mpi_env_var.py
+++ b/test/test_require_mpi_env_var.py
@@ -3,47 +3,53 @@ import inspect
 import unittest
 import os
 
+
 class TestNoMPI(unittest.TestCase):
 
     # Next 3 tests check how the environment variable affects importing MPI
     def test_require_mpi(self):
-        os.environ['PYOPTSPARSE_REQUIRE_MPI'] = '1'
+        os.environ["PYOPTSPARSE_REQUIRE_MPI"] = "1"
         import pyoptsparse.pyOpt_MPI
+
         importlib.reload(pyoptsparse.pyOpt_MPI)
         self.assertTrue(inspect.ismodule(pyoptsparse.pyOpt_MPI.MPI))
 
     def test_no_mpi_requirement_given(self):
-        os.environ.pop('PYOPTSPARSE_REQUIRE_MPI', None)
+        os.environ.pop("PYOPTSPARSE_REQUIRE_MPI", None)
         import pyoptsparse.pyOpt_MPI
+
         importlib.reload(pyoptsparse.pyOpt_MPI)
         self.assertTrue(inspect.ismodule(pyoptsparse.pyOpt_MPI.MPI))
 
     def test_do_not_use_mpi(self):
-        os.environ['PYOPTSPARSE_REQUIRE_MPI'] = '0'
+        os.environ["PYOPTSPARSE_REQUIRE_MPI"] = "0"
         import pyoptsparse.pyOpt_MPI
+
         importlib.reload(pyoptsparse.pyOpt_MPI)
         self.assertFalse(inspect.ismodule(pyoptsparse.pyOpt_MPI.MPI))
 
     # Next 3 tests check how the environment variable affects using ParOpt
     def test_require_mpi_check_paropt(self):
-        os.environ['PYOPTSPARSE_REQUIRE_MPI'] = '1'
+        os.environ["PYOPTSPARSE_REQUIRE_MPI"] = "1"
         import pyoptsparse.pyParOpt.ParOpt
+
         importlib.reload(pyoptsparse.pyParOpt.ParOpt)
         self.assertIsNotNone(pyoptsparse.pyParOpt.ParOpt._ParOpt)
 
     def test_no_mpi_requirement_given_check_paropt(self):
-        os.environ.pop('PYOPTSPARSE_REQUIRE_MPI', None)
+        os.environ.pop("PYOPTSPARSE_REQUIRE_MPI", None)
         import pyoptsparse.pyParOpt.ParOpt
+
         importlib.reload(pyoptsparse.pyParOpt.ParOpt)
         self.assertIsNotNone(pyoptsparse.pyParOpt.ParOpt._ParOpt)
 
     def test_do_not_use_mpi_check_paropt(self):
-        os.environ['PYOPTSPARSE_REQUIRE_MPI'] = '0'
+        os.environ["PYOPTSPARSE_REQUIRE_MPI"] = "0"
         import pyoptsparse.pyParOpt.ParOpt
+
         importlib.reload(pyoptsparse.pyParOpt.ParOpt)
         self.assertIsNone(pyoptsparse.pyParOpt.ParOpt._ParOpt)
 
+
 if __name__ == "__main__":
     unittest.main()
-
-


### PR DESCRIPTION
## Purpose
This PR fixes issue #117.

The goal is to give the user some control over using mpi4py. The user can either say they don't want to run in parallel or explicitly say they must run in parallel. Otherwise, pyoptsparse currently tries to run in parallel as needed but if a suitable mpi4py is not available, there is a fallback to run in serial.

## Type of change
What types of change is it?
- New feature (non-breaking change which adds functionality)

## Testing
One test is to set `PYOPTSPARSE_REQUIRE_MPI` to '0'. Any tests that use ParOpt should fail since ParOpt needs to run in parallel and the environment variable is telling pyoptsparse to run in serial. 

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
