### PR TITLE
Bugfix for mpi4py import

### DIFF
--- a/pyoptsparse/pyOpt_MPI.py
+++ b/pyoptsparse/pyOpt_MPI.py
@@ -55,9 +55,9 @@ else:
         from mpi4py import MPI
     except ImportError:
         warn = (
-            "mpi4py could not be imported. mpi4py is required to use"
-            + "the parallel gradient analysis and parallel objective analysis for"
-            + "non-gradient based optimizers. Continuing using a dummy MPI module"
+            "mpi4py could not be imported. mpi4py is required to use "
+            + "the parallel gradient analysis and parallel objective analysis for "
+            + "non-gradient based optimizers. Continuing using a dummy MPI module "
             + "from pyOptSparse."
         )
         warnings.warn(warn)

--- a/pyoptsparse/pyOpt_MPI.py
+++ b/pyoptsparse/pyOpt_MPI.py
@@ -54,9 +54,11 @@ else:
     try:
         from mpi4py import MPI
     except ImportError:
-        warn = "mpi4py could not be imported. mpi4py is required to use\
-     the parallel gradient analysis and parallel objective analysis for\
-     non-gradient based optimizers. Continuing using a dummy MPI module\
-     from pyOptSparse."
+        warn = (
+            "mpi4py could not be imported. mpi4py is required to use"
+            + "the parallel gradient analysis and parallel objective analysis for"
+            + "non-gradient based optimizers. Continuing using a dummy MPI module"
+            + "from pyOptSparse."
+        )
         warnings.warn(warn)
         MPI = myMPI()

--- a/pyoptsparse/pyParOpt/ParOpt.py
+++ b/pyoptsparse/pyParOpt/ParOpt.py
@@ -7,12 +7,16 @@ import datetime
 # and raise exception on failure. If set to anything else, no import is attempted.
 if "PYOPTSPARSE_REQUIRE_MPI" in os.environ:
     if os.environ["PYOPTSPARSE_REQUIRE_MPI"].lower() in ["always", "1", "true", "yes"]:
-        from paropt import ParOpt as _ParOpt
-        from mpi4py import MPI
+        try:
+            from paropt import ParOpt as _ParOpt
+            from mpi4py import MPI
+        except ImportError:
+            _ParOpt = None
     else:
         _ParOpt = None
-# If PYOPTSPARSE_REQUIRE_MPI is unset, attempt to import mpi4py, but continue on failure
-# with a notification.
+# If PYOPTSPARSE_REQUIRE_MPI is unset, attempt to import mpi4py.
+# Since ParOpt requires mpi4py, if either _ParOpt or mpi4py is unavailable
+# we disable the optimizer.
 else:
     try:
         from paropt import ParOpt as _ParOpt

--- a/test/test_require_mpi_env_var.py
+++ b/test/test_require_mpi_env_var.py
@@ -11,6 +11,13 @@ else:
 
 
 class TestRequireMPIEnvVar(unittest.TestCase):
+    def setUp(self):
+        # check if mpi4py is installed
+        try:
+            import mpi4py  # noqa:F401
+        except ImportError:
+            raise unittest.SkipTest("No mpi4py available, skipping MPI tests.")
+
     # Check how the environment variable affects importing MPI
     def test_require_mpi(self):
         os.environ["PYOPTSPARSE_REQUIRE_MPI"] = "1"


### PR DESCRIPTION
## Purpose
We discovered some issues after merging #118:
- If we specify `PYOPTSPARSE_REQUIRE_MPI` but ParOpt does not exist, then an `ImportError` is raised
- If `mpi4py` does not exist, then some tests fail (but they are expected to fail since it specifies that we must use `mpi4py`)

I have updated the logic to check both imports, as well as which tests should pass/fail depending on if `mpi4py` exists.

I also updated formatting of one long string used to warn users when `mpi4py` does not exist.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Bugfix (non-breaking change which fixes an issue)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
