### PR TITLE
Update installation instructions for skipping NSGA2

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -14,7 +14,9 @@ Please make sure these are installed and available for use.
 In order to use NSGA2 and NOMAD, SWIG (v1.3+) is also required.
 If those optimizers are not needed, then you do not need to install SWIG.
 Simply comment out the corresponding lines in ``pyoptsparse/pyoptsparse/setup.py`` so that they are not compiled.
-Python dependencies are automatically handled by ``pip``.
+The corresponding lines in `pyoptsparse/__init__.py` must be commented out as well.
+
+Python dependencies are automatically handled by ``pip``, so they do not need to be installed separately.
 
 .. note::
   * In Linux, the python header files (python-dev) are also required.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -14,7 +14,7 @@ Please make sure these are installed and available for use.
 In order to use NSGA2 and NOMAD, SWIG (v1.3+) is also required.
 If those optimizers are not needed, then you do not need to install SWIG.
 Simply comment out the corresponding lines in ``pyoptsparse/pyoptsparse/setup.py`` so that they are not compiled.
-The corresponding lines in `pyoptsparse/__init__.py` must be commented out as well.
+The corresponding lines in ``pyoptsparse/__init__.py`` must be commented out as well.
 
 Python dependencies are automatically handled by ``pip``, so they do not need to be installed separately.
 


### PR DESCRIPTION
## Purpose
I updated the installation instructions, specifically for when SWIG is unavailable and the user does not require NSGA2.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Documentation update
