### PR TITLE
Update ipopt

### DIFF
--- a/doc/optimizers/pyipopt.rst
+++ b/doc/optimizers/pyipopt.rst
@@ -47,6 +47,7 @@ Here we explain a basic setup using MUMPS as the linear solver, together with ME
    .. code-block:: bash
 
       # build IPOPT
+      cd $IPOPT_DIR
       mkdir build
       cd build
       ../configure --prefix=${IPOPT_DIR} --disable-java --with-mumps --with-mumps-lflags="-L${IPOPT_DIR}/lib -lcoinmumps" \

--- a/doc/optimizers/pyipopt.rst
+++ b/doc/optimizers/pyipopt.rst
@@ -1,56 +1,79 @@
-.. _ipopt:
-
 IPOPT
 =====
 IPOPT (Interior Point OPTimizer) is an open source interior point optimizer, designed for large-scale nonlinear optimization.
 The source code can be found `here <https://www.coin-or.org/download/source/Ipopt/>`_.
-The latest version we support is 3.11.7.
+The latest version we support is 3.13.2.
 
 Installation
 ------------
+IPOPT must be installed separately, then linked to pyOptSparse when building.
+For the full installation instructions, please see `their documentation <https://coin-or.github.io/Ipopt/INSTALL.html>`_.
+OpenMDAO also has a very helpful `script <https://github.com/OpenMDAO/build_pyoptsparse/>`_ which can be used to install IPOPT with other linear solvers.
+Here we explain a basic setup using MUMPS as the linear solver, together with METIS adapted from the OpenMDAO script.
 
-Install instructions for ``pyIPOPT``.
+#. Download the tarball and extract it to ``$IPOPT_DIR`` which could be set to for example ``$HOME/packages/Ipopt``.
 
-#. Download ``IPopt-3.11.7.tar.gz`` and put in the ``/pyoptsparse/pyoptsparse/pyIPOPT`` directory
+#. Install METIS, which can be used to improve the performance of the MUMPS linear solver.
 
-#. Untar
+   .. code-block:: bash
 
-#. Rename the directory from ``Ipopt-x.x.x`` to ``Ipopt``
+      # build METIS
+      cd $IPOPT_DIR
+      git clone https://github.com/coin-or-tools/ThirdParty-Metis.git
+      cd ThirdParty-Metis
+      ./get.Metis
+      ./configure --prefix=$IPOPT_DIR
+      make
+      make install
 
-#. Obtain the MA27 linear solver from `HSL <http://www.hsl.rl.ac.uk/download/MA27/1.0.0/a/>`_. Rename the source file ``ma27ad.f`` and put it in the ``Ipopt/ThirdParty/HSLold/`` directory
+#. Install MUMPS
 
-#. Go to::
+   .. code-block:: bash
 
-     Ipopt/ThirdParty/Blas/
+      # build MUMPS
+      cd $IPOPT_DIR
+      git clone https://github.com/coin-or-tools/ThirdParty-Mumps.git
+      cd ThirdParty-Mumps
+      ./get.Mumps
+      ./configure --with-metis --with-metis-lflags="-L${IPOPT_DIR}/lib -lcoinmetis" \
+           --with-metis-cflags="-I${IPOPT_DIR}/include -I${IPOPT_DIR}/include/coin-or -I${IPOPT_DIR}/include/coin-or/metis" \
+           --prefix=$IPOPT_DIR CFLAGS="-I${IPOPT_DIR}/include -I${IPOPT_DIR}/include/coin-or -I${IPOPT_DIR}/include/coin-or/metis" \
+           FCFLAGS="-I${IPOPT_DIR}/include -I${IPOPT_DIR}/include/coin-or -I${IPOPT_DIR}/include/coin-or/metis"
+      make
+      make install
 
-   and run::
+#. Build IPOPT
 
-     sh ./get.Blas
+   .. code-block:: bash
 
-   This will download a blas copy and ``Ipopt`` will use that.
+      # build IPOPT
+      mkdir build
+      cd build
+      ../configure --prefix=${IPOPT_DIR} --disable-java --with-mumps --with-mumps-lflags="-L${IPOPT_DIR}/lib -lcoinmumps" \
+           --with-mumps-cflags="-I${IPOPT_DIR}/include/coin-or/mumps"
+      make
+      make install     
 
-#. Go to::
+#. You must add the IPOPT library path to the ``LD_LIBRARY_PATH`` variable for things to work right.
+   This could be done for example by adding the following to your ``.bashrc``::
 
-     Ipopt/ThirdParty/Lapack/
+     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$IPOPT_DIR/lib
 
-   and run::
+   Furthermore, the environment variable ``$IPOPT_DIR`` must be set correctly in order to link to pyOptSparse.
+   Alternatively, you can manually define the variables ``$IPOPT_LIB`` and ``$IPOPT_INC`` for the lib and include paths separately.
 
-     sh ./get.Lapack
 
-#. Run in the root directory::
+#. Now clean build pyOptSparse. Verify that IPOPT works by running the relevant tests.
 
-     $ ./configure --disable-linear-solver-loader
+.. note::
 
-#. Now make::
+   To get IPOPT working with pyOptSparse when using another linear solver, several things must be changed.
 
-     $ make install
-
-#. You must add the ``lib`` directory ``Ipopt`` to your
-   ``LD_LIBRARY_PATH`` variable for things to work right::
-
-     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/user/hg/pyoptsparse/pyoptsparse/pyIPOPT/Ipopt/lib
-
-#. Now the pyOptSparse builder (run from the root directory) should take care of the rest. 
+   #. The ``setup.py`` file located in ``pyoptsparse/pyIPOPT`` must be updated accordingly.
+      In particular, the ``libraries=`` line must be changed to reflect the alternate linear solver.
+      For  example, for HSL you need to replace ``coinmumps`` and ``coinmetis`` with ``coinhsl``.
+   #. The option ``linear_solver`` in the options dictionary must be changed.
+      The default value can be changed in ``pyIPOPT.py`` so that this option does not need to be manually set in every run script.
 
 Options
 -------

--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -223,7 +223,7 @@ class IPOPT(Optimizer):
             "warm_start_mult_init_max": [float, 1e06],
             "warm_start_entire_iterate": [float, "no"],
             # Linear Solver.
-            "linear_solver": [str, "ma27"],
+            "linear_solver": [str, "mumps"],
             "linear_system_scaling": [str, "none"],  # Had been "mc19", but not always available.
             "linear_scaling_on_demand": [str, "yes"],
             # Step Calculation.

--- a/pyoptsparse/pyIPOPT/setup.py
+++ b/pyoptsparse/pyIPOPT/setup.py
@@ -51,7 +51,7 @@ def configuration(parent_package="", top_path=None):
             "pyipoptcore",
             FILES,
             library_dirs=[IPOPT_LIB],
-            libraries=["ipopt", "coinhsl", "dl", "m", "blas", "lapack"],
+            libraries=["ipopt", "coinmumps", "coinmetis", "dl", "m", "blas", "lapack"],
             extra_link_args=["-Wl,-rpath,%s -L%s" % (IPOPT_LIB, IPOPT_LIB)],
             include_dirs=[numpy_include, IPOPT_INC],
         )

--- a/pyoptsparse/pyIPOPT/setup.py
+++ b/pyoptsparse/pyIPOPT/setup.py
@@ -41,7 +41,7 @@ def configuration(parent_package="", top_path=None):
     elif os.getenv("IPOPT_DIR") is not None:
         IPOPT_DIR = os.getenv("IPOPT_DIR")
         IPOPT_LIB = os.path.join(IPOPT_DIR, "lib")
-        IPOPT_INC = os.path.join(IPOPT_DIR, "include/coin/")
+        IPOPT_INC = os.path.join(IPOPT_DIR, "include/coin-or/")
         add_ipopt = True
 
     if add_ipopt:


### PR DESCRIPTION
## Purpose
I updated the installation instructions to install the latest version of IPOPT with pyOptSparse. There are minor changes to the `setup.py` but most of it is just updating the docs. One key change is that I have defaulted to the MUMPS linear solver, since it can be downloaded and installed without any registration required.

Note that the tests may fail since the Docker image has not been updated, but once that is done everything should work just fine. Reviewers are encouraged to follow the instructions and install IPOPT to verify this PR.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- New feature (non-breaking change which adds functionality)
- Documentation update

## Testing
The IPOPT tests work with the latest version of IPOPT.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
