### PR TITLE
Additional linear constraint fixes

### DIFF
--- a/pyoptsparse/pyOpt_history.py
+++ b/pyoptsparse/pyOpt_history.py
@@ -436,6 +436,8 @@ class History(object):
             if not self.optProb.constraints[con].linear:
                 conDict[con] = d["funcs"][con]
             else:
+                # the linear constraints are removed from optProb so that scaling works
+                # without needing the linear constraints to be present
                 self.optProb.constraints.pop(con)
         objDict = {}
         for obj in self.objNames:

--- a/pyoptsparse/pyOpt_history.py
+++ b/pyoptsparse/pyOpt_history.py
@@ -257,10 +257,8 @@ class History(object):
         # only do this if we open the file with 'r' flag
         if self.flag != "r":
             return
-        conNames = list(self.conInfo.keys())
-        for con in conNames:
-            if self.optProb.constraints[con].linear:
-                conNames.remove(con)
+        # we remove linear constraints
+        conNames = [con for con in self.conInfo.keys() if not self.optProb.constraints[con].linear]
         return copy.deepcopy(conNames)
 
     def getObjNames(self):
@@ -433,7 +431,7 @@ class History(object):
         These are all "flat" dictionaries, with simple key:value pairs.
         """
         conDict = {}
-        for con in self.optProb.constraints.keys():
+        for con in list(self.optProb.constraints.keys()):
             # linear constraints are not stored in funcs
             if not self.optProb.constraints[con].linear:
                 conDict[con] = d["funcs"][con]

--- a/pyoptsparse/pyOpt_history.py
+++ b/pyoptsparse/pyOpt_history.py
@@ -433,10 +433,12 @@ class History(object):
         These are all "flat" dictionaries, with simple key:value pairs.
         """
         conDict = {}
-        for con in self.conNames:
+        for con in self.optProb.constraints.keys():
             # linear constraints are not stored in funcs
             if not self.optProb.constraints[con].linear:
                 conDict[con] = d["funcs"][con]
+            else:
+                self.optProb.constraints.pop(con)
         objDict = {}
         for obj in self.objNames:
             objDict[obj] = d["funcs"][obj]

--- a/test/test_tp109.py
+++ b/test/test_tp109.py
@@ -139,6 +139,7 @@ class TestTP109(unittest.TestCase):
         self.assertNotIn("lin_con", hist.getConNames())
         self.assertNotIn("lin_con", hist.getConInfo())
         hist.getValues()
+        hist.getValues(scale=True)
 
     def test_slsqp(self):
         self.optimize("slsqp", 1e-7)


### PR DESCRIPTION
## Purpose
This PR fixes two more bugs with the linear constraints:
- casting the constraint dict_keys into a list, so that the dictionary does not mutate during the loop if an item is removed. This bug was not caught by the test since the linear constraint was always the last constraint in the way the test was set up, and therefore was unaffected
- Simplified the way `conNames` was computed, somehow the previous implementation did not work as expected

I also added a test to `getValues` that tests the scale option.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Bugfix (non-breaking change which fixes an issue)

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
