### PR TITLE
fixed the IPOPT installation bug

### DIFF
--- a/pyoptsparse/pyIPOPT/setup.py
+++ b/pyoptsparse/pyIPOPT/setup.py
@@ -32,7 +32,7 @@ def configuration(parent_package="", top_path=None):
     if os.path.exists("pyoptsparse/pyIPOPT/Ipopt"):
         IPOPT_DIR = os.path.join(top_path, "pyoptsparse/pyIPOPT/Ipopt/")
         IPOPT_LIB = os.path.join(top_path, "pyoptsparse/pyIPOPT/Ipopt/lib")
-        IPOPT_INC = os.path.join(IPOPT_DIR, "include/coin/")
+        IPOPT_INC = os.path.join(IPOPT_DIR, "include/coin-or/")
         add_ipopt = True
     elif os.getenv("IPOPT_INC") is not None and os.getenv("IPOPT_LIB") is not None:
         IPOPT_LIB = os.getenv("IPOPT_LIB")


### PR DESCRIPTION
## Purpose
Fix an installation issue for the IPOPT solver. This specifically addresses the case when `$IPOPT_DIR` is set to `pyoptsparse/pyoptsparse/pyIPOPT/IPOPT`. The issue is #152 .

## Type of change
- Bugfix (non-breaking change which fixes an issue)
