### PR TITLE
Remove python 2 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '27', '37', '38' ]
+        python-version: [ '37', '38' ]
     steps:
     - uses: actions/checkout@v2
     - name: Black Code Formatter
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '2.7', '3.7', '3.8' ]
+        python-version: [ '3.7', '3.8' ]
     name: flake8 with Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,15 +55,15 @@ install:
       docker exec -it app /bin/bash -c "cp -r \$HOME/NLPQLP/* $NLPQLP_DIR/ && cp -r \$HOME/SNOPT/* $SNOPT_DIR/";
     fi
   # Build and install
-  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc && cd $DOCKER_WORKING_DIR && pip install -e ."
+  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && pip install -e ."
 script:
   # We need to source the mdolab bashrc before running anything
-  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc && cd $DOCKER_WORKING_DIR && testflo --pre_announce -v . --coverage --coverpkg $REPO_NAME"
+  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && testflo --pre_announce -v . --coverage --coverpkg $REPO_NAME"
 
 after_success:
   # Coveralls
   # These environment variables must be exposed to coveralls for it to work (since we are on Docker)
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-      docker exec -it app /bin/bash -c ". \$HOME/.bashrc && pip install coveralls";
-      docker exec -e COVERALLS_REPO_TOKEN="$COVERALLS_REPO_TOKEN" -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" -it app /bin/bash -c ". \$HOME/.bashrc && cd $DOCKER_WORKING_DIR && coveralls --rcfile=.coveragerc";
+      docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && pip install coveralls";
+      docker exec -e COVERALLS_REPO_TOKEN="$COVERALLS_REPO_TOKEN" -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && coveralls --rcfile=.coveragerc";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,8 @@ env:
     - DOCKER_TAG=c7-intel-impi-latest
     - DOCKER_TAG=u18-gcc-ompi-stable
     - DOCKER_TAG=u18-gcc-ompi-latest
-    - DOCKER_TAG=u18-gcc-ompi-stable
-    - DOCKER_TAG=u20-gcc-ompi-latest
     - DOCKER_TAG=u20-gcc-ompi-stable
+    - DOCKER_TAG=u20-gcc-ompi-latest
 
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,19 @@ services:
   - docker
 env:
   global:
-    - REPO_NAME=pyoptsparse
+    - REPO_NAME=$(eval basename $TRAVIS_REPO_SLUG)
     - DOCKER_WORKING_DIR=/home/mdolabuser/packages/$REPO_NAME
     - DOCKER_MOUNT_DIR=/home/mdolabuser/travis/$REPO_NAME
-    - SNOPT_DIR=$DOCKER_WORKING_DIR/pyoptsparse/pySNOPT/source
-    - NLPQLP_DIR=$DOCKER_WORKING_DIR/pyoptsparse/pyNLPQLP/source
+    - SNOPT_DIR=$DOCKER_WORKING_DIR/$REPO_NAME/pySNOPT/source
+    - NLPQLP_DIR=$DOCKER_WORKING_DIR/$REPO_NAME/pyNLPQLP/source
   jobs:
-    # - DOCKER_TAG=c7-gcc-ompi-py3-latest
-    - DOCKER_TAG=c7-intel-impi-py3-latest
-    - DOCKER_TAG=u18-gcc-ompi-py2-stable
-    - DOCKER_TAG=u18-gcc-ompi-py3-latest
-    - DOCKER_TAG=u18-gcc-ompi-py3-stable
-    - DOCKER_TAG=u20-gcc-ompi-py3-latest
-    - DOCKER_TAG=u20-gcc-ompi-py3-stable
+    # - DOCKER_TAG=c7-gcc-ompi-latest
+    - DOCKER_TAG=c7-intel-impi-latest
+    - DOCKER_TAG=u18-gcc-ompi-stable
+    - DOCKER_TAG=u18-gcc-ompi-latest
+    - DOCKER_TAG=u18-gcc-ompi-stable
+    - DOCKER_TAG=u20-gcc-ompi-latest
+    - DOCKER_TAG=u20-gcc-ompi-stable
 
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
@@ -50,21 +50,20 @@ install:
   - docker exec -it app /bin/bash -c "rm -rf $DOCKER_WORKING_DIR && cp -r $DOCKER_MOUNT_DIR $DOCKER_WORKING_DIR"
   # We also remove the python installation
   - docker exec -it app /bin/bash -c "rm -rf $DOCKER_WORKING_DIR/build"
-  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && pip install testflo==1.3.5"
   # Copy back the proprietary codes
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
       docker exec -it app /bin/bash -c "cp -r \$HOME/NLPQLP/* $NLPQLP_DIR/ && cp -r \$HOME/SNOPT/* $SNOPT_DIR/";
     fi
   # Build and install
-  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && pip install -e ."
+  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc && cd $DOCKER_WORKING_DIR && pip install -e ."
 script:
   # We need to source the mdolab bashrc before running anything
-  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && testflo --pre_announce -v . --coverage --coverpkg pyoptsparse"
+  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc && cd $DOCKER_WORKING_DIR && testflo --pre_announce -v . --coverage --coverpkg $REPO_NAME"
 
 after_success:
   # Coveralls
   # These environment variables must be exposed to coveralls for it to work (since we are on Docker)
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-      docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && pip install coveralls";
-      docker exec -e COVERALLS_REPO_TOKEN="$COVERALLS_REPO_TOKEN" -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && coveralls --rcfile=.coveragerc";
+      docker exec -it app /bin/bash -c ". \$HOME/.bashrc && pip install coveralls";
+      docker exec -e COVERALLS_REPO_TOKEN="$COVERALLS_REPO_TOKEN" -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" -it app /bin/bash -c ". \$HOME/.bashrc && cd $DOCKER_WORKING_DIR && coveralls --rcfile=.coveragerc";
     fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # pyOptSparse - PYthon OPTimization (Sparse) Framework
 
+[![Python 3.7+](https://img.shields.io/badge/python-3.7+-blue.svg)](https://www.python.org/downloads/release/python-370/)
 [![Build Status](https://travis-ci.com/mdolab/pyoptsparse.svg?branch=master)](https://travis-ci.com/mdolab/pyoptsparse)
 [![Coverage Status](https://coveralls.io/repos/github/mdolab/pyoptsparse/badge.svg?branch=master)](https://coveralls.io/github/mdolab/pyoptsparse?branch=master)
 [![Documentation Status](https://readthedocs.com/projects/mdolab-pyoptsparse/badge/?version=latest)](https://mdolab-pyoptsparse.readthedocs-hosted.com/en/latest/?badge=latest)

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -7,7 +7,7 @@ Requirements
 ------------
 pyOptSparse has the following dependencies:
 
-* Python 2.7, 3.7 or 3.8, though other Python 3 versions will likely work
+* Python 3.7 or 3.8, though other Python 3 versions will likely work
 * C and Fortran compilers.
   We recommend ``gcc`` and ``gfortran`` which can be installed via the package manager for your operating system.
 

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -5,9 +5,6 @@
 import copy
 import os
 from collections import OrderedDict
-
-from six import iteritems, iterkeys, next
-
 from sqlitedict import SqliteDict
 
 # =============================================================================
@@ -1343,9 +1340,8 @@ class Optimization(object):
 
         cond = False
         # this version is required for python 3 compatibility
-        cond = isinstance(next(iterkeys(funcsSens)), str)
-
-        if cond:
+        cond = isinstance(list(funcsSens.keys())[0], str)
+        if cond:  # we have a nested dictionary
             iObj = 0
             for objKey in self.objectives.keys():
                 if objKey in funcsSens:
@@ -1370,7 +1366,7 @@ class Optimization(object):
                     raise Error("The key for the objective gradient, '%s', was not found." % objKey)
                 iObj += 1
         else:  # Then it must be a tuple; assume flat dict
-            for (objKey, dvGroup), _ in iteritems(funcsSens):
+            for (objKey, dvGroup), val in funcsSens.items():
                 if objKey in self.objectives.keys():
                     try:
                         iObj = self.objectiveIdx[objKey]
@@ -1380,7 +1376,7 @@ class Optimization(object):
                         ss = self.dvOffset[dvGroup]
                     except KeyError:
                         raise Error("The dvGroup key '%s' is not valid" % dvGroup)
-                    tmp = np.array(funcsSens[objKey, dvGroup]).squeeze()
+                    tmp = np.array(val).squeeze()
                     if tmp.size == ss[1] - ss[0]:
                         # Everything checks out so set:
                         gobj[iObj, ss[0] : ss[1]] = tmp
@@ -1389,7 +1385,7 @@ class Optimization(object):
                             (
                                 "The shape of the objective derivative for dvGroup '{}' is the incorrect length. "
                                 + "Expecting a shape of {} but received a shape of {}."
-                            ).format(dvGroup, (ss[1] - ss[0],), funcsSens[objKey, dvGroup].shape)
+                            ).format(dvGroup, (ss[1] - ss[0],), val.shape)
                         )
 
         # Note that we looped over the keys in funcsSens[objKey]

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
         description="Python package for formulating and solving nonlinear constrained optimization problems",
         long_description="pyOptSparse is a Python package for formulating and solving nonlinear constrained optimization problems",
         keywords="optimization",
-        install_requires=["sqlitedict>=1.6", "numpy>=1.16", "scipy>1.2", "six>=1.13"],
+        install_requires=["sqlitedict>=1.6", "numpy>=1.16", "scipy>1.2"],
         platforms=["Linux"],
         classifiers=[
             "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
## Purpose
This PR removes support for Python 2. Once this is merged, pyOptSparse will no longer work with Python 2.
The main change was just removing the `six` package and changing the syntax to use the native py3 iterators.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Breaking change (non-backwards-compatible fix or feature)

## Testing
All existing tests pass on py3.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
