### PR TITLE
Include non-objective/constraint functions in history output

### DIFF
--- a/pyoptsparse/pyOpt_history.py
+++ b/pyoptsparse/pyOpt_history.py
@@ -532,7 +532,8 @@ class History(object):
             return
 
         allNames = (
-            self.DVNames.union(self.conNames)
+            self.DVNames.union(self.db["0"]["funcs"].keys())
+            .union(self.conNames)
             .union(self.objNames)
             .union(self.iterKeys)
             .difference(set(["funcs", "funcsSens", "xuser"]))
@@ -615,6 +616,8 @@ class History(object):
                                 data[name].append(conDict[name])
                             elif name in self.objNames:
                                 data[name].append(objDict[name])
+                            elif name in val["funcs"].keys():
+                                data[name].append(val["funcs"][name])
                             else:  # must be opt
                                 data[name].append(val[name])
                     elif val["fail"] and user_specified_callCounter:

--- a/pyoptsparse/pyOpt_history.py
+++ b/pyoptsparse/pyOpt_history.py
@@ -209,9 +209,14 @@ class History(object):
 
         # extract all information stored in the call counters
         self.iterKeys = set()
+        self.extraFuncsNames = set()
         for i in self.callCounters:
             val = self.read(i)
             self.iterKeys.update(val.keys())
+            if "funcs" in val.keys():
+                self.extraFuncsNames.update(val["funcs"].keys())
+        # remove objective and constraint keys
+        self.extraFuncsNames = self.extraFuncsNames.difference(self.conNames).difference(self.objNames)
 
         from .__init__ import __version__
 
@@ -282,6 +287,22 @@ class History(object):
         if self.flag != "r":
             return
         return copy.deepcopy(list(self.objInfo.keys()))
+
+    def getExtraFuncsNames(self):
+        """
+        Returns extra funcs names.
+        These are extra key: value pairs stored in the ``funcs`` dictionary for each iteration, which are not used by the optimizer.
+
+        Returns
+        -------
+        list of str
+            A list containing the names of extra funcs keys.
+
+        """
+        # only do this if we open the file with 'r' flag
+        if self.flag != "r":
+            return
+        return copy.deepcopy(list(self.extraFuncsNames))
 
     def getObjInfo(self, key=None):
         """
@@ -532,10 +553,10 @@ class History(object):
             return
 
         allNames = (
-            self.DVNames.union(self.db["0"]["funcs"].keys())
-            .union(self.conNames)
+            self.DVNames.union(self.conNames)
             .union(self.objNames)
             .union(self.iterKeys)
+            .union(self.extraFuncsNames)
             .difference(set(["funcs", "funcsSens", "xuser"]))
         )
         # cast string input into a single list
@@ -616,7 +637,7 @@ class History(object):
                                 data[name].append(conDict[name])
                             elif name in self.objNames:
                                 data[name].append(objDict[name])
-                            elif name in val["funcs"].keys():
+                            elif name in self.extraFuncsNames:
                                 data[name].append(val["funcs"][name])
                             else:  # must be opt
                                 data[name].append(val[name])

--- a/test/test_hs015.py
+++ b/test/test_hs015.py
@@ -31,6 +31,9 @@ class TestHS15(unittest.TestCase):
         conval[0] = x[0] * x[1]
         conval[1] = x[0] + x[1] ** 2
         funcs["con"] = conval
+        # extra keys
+        funcs["extra1"] = 0.0
+        funcs["extra2"] = 1.0
         fail = False
         return funcs, fail
 
@@ -142,10 +145,18 @@ class TestHS15(unittest.TestCase):
         last = hist.read("last")  # 'last' key should be present
         self.assertIn(last, callCounters)
 
-        # iterKey checks
+        # iterKeys checks
         iterKeys = hist.getIterKeys()
         for key in ["xuser", "fail", "isMajor"]:
             self.assertIn(key, iterKeys)
+
+        # extraFuncsNames checks
+        extraFuncsNames = hist.getExtraFuncsNames()
+        for key in ["extra1", "extra2"]:
+            self.assertIn(key, extraFuncsNames)
+
+        # getValues checks
+        val = hist.getValues()
 
         # this check is only used for optimizers that guarantee '0' and 'last' contain funcs
         if optimizer in ["SNOPT", "SLSQP", "PSQP"]:


### PR DESCRIPTION
## Purpose
Currently, the `getValues` method in the `pyOpt_history` class only returns the histories of functions that are used as objectives or constraints. However, sometimes there are other functions of interest not used as either that user may want to track the history of anyway. This fix allows this by adding all the functions in the `'funcs'` dict to the list of those that can be returned by `getValues`.

You may want to make some changes to this, I'm not sure if including everything from `self.db["0"]["funcs"]` automatically includes all constraints and objectives or not. Are there also tests that would be affected by this change?

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
