### PR TITLE
Update for SNOPT v7.7.5

### DIFF
--- a/doc/optimizers/pysnopt.rst
+++ b/doc/optimizers/pysnopt.rst
@@ -16,8 +16,9 @@ Installation
 SNOPT is available for purchase `here 
 <http://www.sbsi-sol-optimize.com/asp/sol_snopt.htm>`_. Upon purchase, you should receive a zip file. Within the zip file, there is a folder called ``src``. To use SNOPT with pyoptsparse, paste all files from ``src`` except snopth.f into ``pyoptsparse/pySNOPT/source``.
 
-From v2.0 onwards, only SNOPT v7.7 is officially supported.
+From v2.0 onwards, only SNOPT v7.7.x is officially supported.
 To use pyOptSparse with previous versions of SNOPT, please checkout release v1.2.
+The current version of SNOPT being tested is v7.7.1, although v7.7.5 is also expected to work.
 
 
 Options

--- a/doc/optimizers/pysnopt.rst
+++ b/doc/optimizers/pysnopt.rst
@@ -18,7 +18,7 @@ SNOPT is available for purchase `here
 
 From v2.0 onwards, only SNOPT v7.7.x is officially supported.
 To use pyOptSparse with previous versions of SNOPT, please checkout release v1.2.
-The current version of SNOPT being tested is v7.7.1, although v7.7.5 is also expected to work.
+The current version of SNOPT being tested is v7.7.5, although v7.7.1 is also expected to work.
 
 
 Options

--- a/pyoptsparse/__init__.py
+++ b/pyoptsparse/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.2.2"
+__version__ = "2.3.0"
 
 from .pyOpt_history import History
 from .pyOpt_variable import Variable

--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -555,8 +555,6 @@ class IPOPT(Optimizer):
     def _on_setOption(self, name, value):
         """
         Set Optimizer Option Value (Optimizer Specific Routine)
-
-        Documentation last updated:  May. 07, 2008 - Ruben E. Perez
         """
 
         self.set_options.append([name, value])

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -821,7 +821,7 @@ class Optimizer(object):
                 self.options[name] = [type(value), value]
             else:
                 raise Error(
-                    "Value type for option {} was incorrect. It was expecting type '{}' by received type '{}'".format(
+                    "Value type for option {} was incorrect. It was expecting type '{}' but received type '{}'".format(
                         name, self.options["defaults"][name][0], type(value)
                     )
                 )

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -76,6 +76,7 @@ class SNOPT(Optimizer):
             # SNOPT Other Tolerances Options
             "Crash tolerance": [float, 0.1],
             "Linesearch tolerance": [float, 0.9],  # smaller for more accurate search
+            "Backoff factor": [float, 0.1],  # backtracking factor for failed evaluations
             "Pivot tolerance": [float, 3.7e-11],  # epsilon^(2/3)
             # SNOPT QP subproblems Options
             "QPSolver": [str, "Cholesky"],  # Default: Cholesky
@@ -88,6 +89,7 @@ class SNOPT(Optimizer):
             # SNOPT SQP method Options
             "Major iterations limit": [int, 1000],  # or ncons if that is more
             "Minor iterations limit": [int, 500],  # or 3*ncons if that is more
+            "Proximal iterations limit": [int, 200],  # for solving the proximal point problem
             "Major step limit": [float, 2.0],
             "Superbasics limit": [int, None],  # (n1 + 1, n1 = number of nonlinear variables)
             "Derivative level": [int, 3],  # (NOT ALLOWED IN snOptA)
@@ -224,7 +226,10 @@ class SNOPT(Optimizer):
             if raiseError:
                 raise Error("There was an error importing the compiled snopt module")
 
-        self.set_options = []
+        # any default options modified by pySNOPT goes here
+        self.set_options = [
+            ["Proximal iterations limit", 10000],  # very large # to solve proximal point problem to optimality
+        ]
         Optimizer.__init__(self, name, category, self.defOpts, self.informs, *args, **kwargs)
 
         # SNOPT need Jacobians in csc format

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -703,8 +703,6 @@ class SNOPT(Optimizer):
     def _on_setOption(self, name, value):
         """
         Set Optimizer Option Value (Optimizer Specific Routine)
-
-        Documentation last updated:  May. 07, 2008 - Ruben E. Perez
         """
 
         self.set_options.append([name, value])
@@ -712,8 +710,6 @@ class SNOPT(Optimizer):
     def _on_getOption(self, name):
         """
         Get Optimizer Option Value (Optimizer Specific Routine)
-
-        Documentation last updated:  May. 07, 2008 - Ruben E. Perez
         """
 
         pass
@@ -725,8 +721,6 @@ class SNOPT(Optimizer):
         Keyword arguments:
         -----------------
         id -> STRING: Option Name
-
-        Documentation last updated:  May. 07, 2008 - Ruben E. Perez
         """
 
         #
@@ -743,8 +737,6 @@ class SNOPT(Optimizer):
     def _on_flushFiles(self):
         """
         Flush the Output Files (Optimizer Specific Routine)
-
-        Documentation last updated:  August. 09, 2009 - Ruben E. Perez
         """
 
         #

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -668,10 +668,7 @@ class SNOPT(Optimizer):
         # Set Options from the local options dictionary
         # ---------------------------------------------
         inform = np.array([-1], np.intc)
-        for item in self.set_options:
-            name = item[0]
-            value = item[1]
-
+        for name, value in self.set_options:
             if name == "iPrint" or name == "iSumm":
                 continue
 


### PR DESCRIPTION
## Purpose
This PR extends support for SNOPT v7.7.5, which has the `snLog` call signatures restored so there was no need to modify the f2py interface. Changes are:
- Added `Backoff factor` option to control the backtracking factor during line search when encountering failed function evaluations
- Added `Proximal iterations limit` option for controlling the number of iterations in solving the proximal point problem
- The default value for this option has been changed from 200 to 10000 to ensure we solve the problem to optimality. This was also the default behaviour in the older SNOPT v7.2

Note that since the `Backoff factor` did not exist in v7.7.1, attempting to set it via `optOptions` will result in SNOPT saying 
```
XXX  Keyword not recognized:         BACKOFF
```
however, this is simply a warning and SNOPT will carry on as usual.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
All tests run, both with v7.7.1 and v7.7.5.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
