### PR TITLE
Added option to hide default values in docs

### DIFF
--- a/doc/optimizers/pysnopt.rst
+++ b/doc/optimizers/pysnopt.rst
@@ -25,6 +25,7 @@ Options
 -------
 .. optimizertable:: pyoptsparse.pySNOPT.pySNOPT.SNOPT
    :type: options
+   :nodefvalues:
 
 
 Informs

--- a/doc/optimizers/pysnopt.rst
+++ b/doc/optimizers/pysnopt.rst
@@ -23,6 +23,24 @@ The current version of SNOPT being tested is v7.7.5, although v7.7.1 is also exp
 
 Options
 -------
+The default values come directly from SNOPT, which is why they are not displayed in the table below.
+Please refer to the user manual for those options.
+Note that there are two key differences:
+
+- The SNOPT option ``Proximal iterations limit`` has its default value changed to 10000, in order to fully solve the proximal point problem to optimality
+- The option ``Save major iteration variables`` is unique to the Python wrapper, and takes a list of values which can be saved at each iteration to the History file.
+  Possible values are
+
+  - ``step``
+  - ``merit``
+  - ``feasibility``
+  - ``optimality``
+  - ``penalty``
+  - ``Hessian``
+  - ``slack``
+  - ``lambda``
+  - ``condZHZ``
+
 .. optimizertable:: pyoptsparse.pySNOPT.pySNOPT.SNOPT
    :type: options
    :nodefvalues:


### PR DESCRIPTION
## Purpose
I updated the documentation to explain how SNOPT default options come from the optimizer and are not set by pySNOPT.
I have hidden the default values for SNOPT by modifying the Sphinx extension.
I also checked that other optimizers are using the default values, and that the documentation is consistent with the code.
Closes #135.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)
