### PR TITLE
Changing the SLSQP output file id

### DIFF
--- a/pyoptsparse/pySLSQP/pySLSQP.py
+++ b/pyoptsparse/pySLSQP/pySLSQP.py
@@ -44,7 +44,7 @@ class SLSQP(Optimizer):
             "ACC": [float, 1e-6],  # Convergence Accurancy
             "MAXIT": [int, 500],  # Maximum Iterations
             "IPRINT": [int, 1],  # Output Level (<0 - None, 0 - Screen, 1 - File)
-            "IOUT": [int, 6],  # Output Unit Number
+            "IOUT": [int, 60],  # Output Unit Number
             "IFILE": [str, "SLSQP.out"],  # Output File Name
         }
         self.informs = {


### PR DESCRIPTION
## Purpose
Closes https://github.com/mdolab/MACH-Aero/issues/31. 
File id 6 is often associated with `stdout` and as such was redirecting the adflow output to this file.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Run the tutorial as described in https://github.com/mdolab/MACH-Aero/issues/31.


## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
