### PR TITLE
Extract and store SNOPT version in history file

### DIFF
--- a/doc/api/history.rst
+++ b/doc/api/history.rst
@@ -14,7 +14,8 @@ In this case, the history file would have the following layout::
     │   ├── endTime
     │   ├── optTime
     │   ├── optimizer
-    │   └── version
+    │   ├── version
+    │   └── optVersion
     ├── optProb
     ├── varInfo
     │   └── xvars

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -32,6 +32,7 @@ class Optimizer(BaseSolver):
         options={},
         checkDefaultOptions=True,
         caseSensitiveOptions=True,
+        version=None,
     ):
         """
         This is the base optimizer class that all optimizers inherit from.
@@ -60,6 +61,8 @@ class Optimizer(BaseSolver):
         self.callCounter = 0
         self.sens = None
         self.optProb = None
+        self.version = version
+
         # Default options:
         self.appendLinearConstraints = False
         self.jacType = "dense"
@@ -798,6 +801,7 @@ class Optimizer(BaseSolver):
         self.metadata = {
             "version": __version__,
             "optimizer": self.name,
+            "optVersion": self.version,
             "optName": self.optProb.name,
             "nprocs": MPI.COMM_WORLD.size,
             "optOptions": options,

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -150,17 +150,19 @@ class SNOPT(Optimizer):
         if snopt is None:
             if raiseError:
                 raise Error("There was an error importing the compiled snopt module")
-
-        # extract SNOPT version
-        version_str = snopt.sntitle().decode("utf-8")
-        # The version_str is going to look like
-        # S N O P T  7.7.5    (Oct 2020)
-        # we search between "S N O P T" and "("
-        res = re.search("S N O P T(.*)\(", version_str)
-        if res is not None:
-            version = res.group(1).strip()
+            else:
+                version = None
         else:
-            version = None
+            # extract SNOPT version
+            version_str = snopt.sntitle().decode("utf-8")
+            # The version_str is going to look like
+            # S N O P T  7.7.5    (Oct 2020)
+            # we search between "S N O P T" and "("
+            res = re.search("S N O P T(.*)\(", version_str)
+            if res is not None:
+                version = res.group(1).strip()
+            else:
+                version = None
 
         super().__init__(
             name,

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -16,6 +16,7 @@ except ImportError:
 import os
 import time
 import datetime
+import re
 
 # =============================================================================
 # External Python modules
@@ -150,6 +151,17 @@ class SNOPT(Optimizer):
             if raiseError:
                 raise Error("There was an error importing the compiled snopt module")
 
+        # extract SNOPT version
+        version_str = snopt.sntitle().decode("utf-8")
+        # The version_str is going to look like
+        # S N O P T  7.7.5    (Oct 2020)
+        # we search between "S N O P T" and "("
+        res = re.search("S N O P T(.*)\(", version_str)
+        if res is not None:
+            version = res.group(1).strip()
+        else:
+            version = None
+
         super().__init__(
             name,
             category,
@@ -157,6 +169,7 @@ class SNOPT(Optimizer):
             informs=self.informs,
             options=options,
             checkDefaultOptions=False,
+            version=version,
         )
 
         # SNOPT need Jacobians in csc format

--- a/pyoptsparse/pySNOPT/source/f2py/snopt.pyf
+++ b/pyoptsparse/pySNOPT/source/f2py/snopt.pyf
@@ -348,6 +348,9 @@ python module snopt ! in
             double precision dimension(lenrw) :: rw
             integer optional,check(len(rw)>=lenrw),depend(rw) :: lenrw=len(rw)
         end subroutine sngetr
+        subroutine sntitle(title) ! in :snopt:sn02lib.f
+            character*30, intent(out) :: title
+        end subroutine sntitle
         subroutine snoptc(start,m,n,ne,nname,nncon,nnobj,nnjac,iobj,objadd,prob,userfg,jcol,indj,locj,bl,bu,names,hs,x,pi,rc,inform,mincw,miniw,minrw,ns,ninf,sinf,obj,cu,lencu,iu,leniu,ru,lenru,cw,lencw,iw,leniw,rw,lenrw) ! in :snopt:snoptc.f
             use snoptc__user__routines
             character*(*) intent(inout) :: start

--- a/test/test_hs015.py
+++ b/test/test_hs015.py
@@ -117,9 +117,21 @@ class TestHS15(unittest.TestCase):
         # Metadata checks
         metadata = hist.getMetadata()
         self.assertEqual(metadata["optimizer"], optimizer)
-        metadata_def_keys = ["optName", "optOptions", "nprocs", "startTime", "endTime", "optTime", "version"]
+        metadata_def_keys = [
+            "optName",
+            "optOptions",
+            "nprocs",
+            "startTime",
+            "endTime",
+            "optTime",
+            "version",
+            "optVersion",
+        ]
         for key in metadata_def_keys:
             self.assertIn(key, metadata)
+            # we test that SNOPT version is stored correctly
+            if optimizer == "SNOPT" and key == "optVersion":
+                self.assertNotEqual(metadata[key], None)
         hist.getOptProb()
 
         # Info checks


### PR DESCRIPTION
## Purpose
I added another key to `metadata` called `optVersion`, currently defaulting to `None`. I then wrapped the `snTitle` subroutine to extract the version information from SNOPT, and set it inside Python. This allows the history file to store the SNOPT version information which is useful for reproducibility of results.

Note that docs build will probably fail. I will update the way the options tables are generated and fix this.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I added a new test.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
