### PR TITLE
Fix several issues with hotstart

### DIFF
--- a/doc/advancedFeatures.rst
+++ b/doc/advancedFeatures.rst
@@ -28,11 +28,10 @@ For this process to work, the following must be true:
    If the optimizer performs a random gradient check (e.g. SNOPT), it's best to disable these just in case.
 -  Optimizer settings that affect the path of the optimization must remain the same.
    It is perfectly fine to change for example settings related to print outs, but not those affecting the line search.
--  The hot start file is itself cold started.
-   It is not possible to hot start from another hot start.
 
 To use the hot start feature, simply call the optimizer with the option ``hotStart = <hot start file>``.
 See the API documentation for each optimizer for more information.
+Because the hot start process will store all the previous "restarted" iterations in the new history file, it's possible to restart as many times as you like, each time using the previous history file.
 
 
 

--- a/doc/advancedFeatures.rst
+++ b/doc/advancedFeatures.rst
@@ -10,7 +10,7 @@ Advanced Features
 .. ----------------------------
 
 Hot start
---------
+---------
 Hot start refers to the way optimizations are initialized.
 Suppose you run an optimization, and it was accidentally terminated prematurely, for example due to an iteration limit which was too low.
 If you restarted the optimization from the last iteration, you will likely incur a performance penalty, and end up taking far more steps than it would've taken if the original optimization was allowed to progress.
@@ -24,9 +24,12 @@ If at any point the requested design variables diverge from the history, then we
 For this process to work, the following must be true:
 
 -  The optimizer is deterministic.
-   Note that a stochastic optimizer is still deterministic even if it uses random numbers, as long as the initial seed is fixed.
+   Note that a stochastic optimizer can still be made deterministic even if it uses random numbers, as long as the random seed is fixed.
+   If the optimizer performs a random gradient check (e.g. SNOPT), it's best to disable these just in case.
 -  Optimizer settings that affect the path of the optimization must remain the same.
    It is perfectly fine to change for example settings related to print outs, but not those affecting the line search.
+-  The hot start file is itself cold started.
+   It is not possible to hot start from another hot start.
 
 To use the hot start feature, simply call the optimizer with the option ``hotStart = <hot start file>``.
 See the API documentation for each optimizer for more information.

--- a/doc/advancedFeatures.rst
+++ b/doc/advancedFeatures.rst
@@ -12,14 +12,14 @@ Advanced Features
 Hot start
 ---------
 Hot start refers to the way optimizations are initialized.
-Such start-up procedure is named in contrast to the regular optimization intialization, or "cold start", in which case pyOptSparse simply initializes an optimization job from scratch, using an arbitrary, user-defined set of initial design variables.
-There are several situations in which such cold optimization starts can be avoided by leveraging on the information from a previous optimization, with the aim to reduce the overall computational time.
+Such start-up procedure is named in contrast to the regular optimization initialization, or "cold start", in which case pyOptSparse simply initializes an optimization job from scratch, using initial design variables set by the user.
+There are several situations in which such cold starts can be avoided by leveraging on the information from a previous optimization, with the aim to reduce the overall computational time.
 Suppose you run an optimization that was accidentally terminated prematurely by, for example, an excessively-low iteration limit.
 If you restarted the optimization using the DVs from the last iteration (but losing all the accumulated history), you will start from a better initial point but will likely incur in a performance penalty.
 The overall optimization, now split between two jobs, will end up taking far more steps than it would've taken if the original optimization was allowed to progress.
-This is due to the fact that some of the optimizers wrapped in pyOptSparse need a few initial iterations build a (local) approximation of the design space.
-Because of this lack of information, the first few major steps of a cold-started optimization are in general more expensive than the later iterations in terms of function (and sensitivity) evaluations.
-In a sense, many optimizers the next iterate does not depend only on the current iterate, but effectively all the previous iterates as well!
+This is due to the fact that some of the optimizers wrapped in pyOptSparse need a few initial iterations to build a (local) approximation of the design space.
+Because of this lack of information, there is a start-up cost to a cold started optimization, where the optimizer has to spend time rebuilding the information.
+In a sense, for many optimizers the next iterate does not depend only on the current iterate, but effectively all the previous iterates as well!
 
 Hot starting optimizations is a way to address this issue.
 pyOptSparse has the ability to read in the previous optimization history file, and `replay` the entire history starting at the original design variables, feeding ``funcs`` to the optimizer each time.

--- a/doc/advancedFeatures.rst
+++ b/doc/advancedFeatures.rst
@@ -1,0 +1,40 @@
+Advanced Features
+=================
+.. Gradient Evaluation with Complex Step
+.. -------------------------------------
+
+.. Parallel Execution
+.. ------------------
+
+.. Storing Optimization History
+.. ----------------------------
+
+Hot start
+--------
+Hot start refers to the way optimizations are initialized.
+Suppose you run an optimization, and it was accidentally terminated prematurely, for example due to an iteration limit which was too low.
+If you restarted the optimization from the last iteration, you will likely incur a performance penalty, and end up taking far more steps than it would've taken if the original optimization was allowed to progress.
+This is because for many optimizers, the next iterate does not depend only on the current iterate, but effectively all the previous iterates as well.
+In a sense, these optimizers are path-dependent, and when you restart the optimization you lose all the accumulated history.
+
+Hot starting optimizations is a way to address this issue.
+pyOptSparse has the ability to read in the previous optimization history file, and `replay` the entire history starting at the original design variables, feeding ``funcs`` to the optimizer each time.
+For a deterministic optimizer, if all solver settings remain the same, then it should request the same sequence of iterates (up to machine precision), and if those have been previously evaluated, they are read from the history file and passed to the optimizer.
+If at any point the requested design variables diverge from the history, then we will actually perform a function evaluation, and all subsequent points will be newly evaluated.
+For this process to work, the following must be true:
+
+-  The optimizer is deterministic.
+   Note that a stochastic optimizer is still deterministic even if it uses random numbers, as long as the initial seed is fixed.
+-  Optimizer settings that affect the path of the optimization must remain the same.
+   It is perfectly fine to change for example settings related to print outs, but not those affecting the line search.
+
+To use the hot start feature, simply call the optimizer with the option ``hotStart = <hot start file>``.
+See the API documentation for each optimizer for more information.
+
+
+
+.. Time limit
+.. ----------
+
+.. Clean Optimization Termination
+.. ------------------------------

--- a/doc/advancedFeatures.rst
+++ b/doc/advancedFeatures.rst
@@ -12,10 +12,14 @@ Advanced Features
 Hot start
 ---------
 Hot start refers to the way optimizations are initialized.
-Suppose you run an optimization, and it was accidentally terminated prematurely, for example due to an iteration limit which was too low.
-If you restarted the optimization from the last iteration, you will likely incur a performance penalty, and end up taking far more steps than it would've taken if the original optimization was allowed to progress.
-This is because for many optimizers, the next iterate does not depend only on the current iterate, but effectively all the previous iterates as well.
-In a sense, these optimizers are path-dependent, and when you restart the optimization you lose all the accumulated history.
+Such start-up procedure is named in contrast to the regular optimization intialization, or "cold start", in which case pyOptSparse simply initializes an optimization job from scratch, using an arbitrary, user-defined set of initial design variables.
+There are several situations in which such cold optimization starts can be avoided by leveraging on the information from a previous optimization, with the aim to reduce the overall computational time.
+Suppose you run an optimization that was accidentally terminated prematurely by, for example, an excessively-low iteration limit.
+If you restarted the optimization using the DVs from the last iteration (but losing all the accumulated history), you will start from a better initial point but will likely incur in a performance penalty.
+The overall optimization, now split between two jobs, will end up taking far more steps than it would've taken if the original optimization was allowed to progress.
+This is due to the fact that some of the optimizers wrapped in pyOptSparse need a few initial iterations build a (local) approximation of the design space.
+Because of this lack of information, the first few major steps of a cold-started optimization are in general more expensive than the later iterations in terms of function (and sensitivity) evaluations.
+In a sense, many optimizers the next iterate does not depend only on the current iterate, but effectively all the previous iterates as well!
 
 Hot starting optimizations is a way to address this issue.
 pyOptSparse has the ability to read in the previous optimization history file, and `replay` the entire history starting at the original design variables, feeding ``funcs`` to the optimizer each time.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -26,6 +26,7 @@ To get started, please see the :ref:`install` and the :ref:`quickstart`.
    install
    quickstart
    guide
+   advancedFeatures
    postprocessing
    changes
    contribute

--- a/doc/optimizers/SNOPT.rst
+++ b/doc/optimizers/SNOPT.rst
@@ -18,7 +18,7 @@ SNOPT is available for purchase `here
 
 From v2.0 onwards, only SNOPT v7.7.x is officially supported.
 To use pyOptSparse with previous versions of SNOPT, please checkout release v1.2.
-The current version of SNOPT being tested is v7.7.5, although v7.7.1 is also expected to work.
+We currently test v7.7.7 and v7.7.1.
 
 
 Options

--- a/pyoptsparse/__init__.py
+++ b/pyoptsparse/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 
 from .pyOpt_history import History
 from .pyOpt_variable import Variable

--- a/pyoptsparse/pyALPSO/pyALPSO.py
+++ b/pyoptsparse/pyALPSO/pyALPSO.py
@@ -121,6 +121,8 @@ class ALPSO(Optimizer):
         self.optProb = optProb
         self.optProb.finalizeDesignVariables()
         self.optProb.finalizeConstraints()
+        # Set history/hotstart/coldstart
+        self._setHistory(storeHistory, None)
         self._setInitialCacheValues()
 
         if len(optProb.constraints) == 0:
@@ -148,8 +150,6 @@ class ALPSO(Optimizer):
             me = len(indices)
 
         if self.optProb.comm.rank == 0:
-            # Set history/hotstart/coldstart
-            self._setHistory(storeHistory, None)
 
             # Setup argument list values
             opt = self.getOption

--- a/pyoptsparse/pyCONMIN/pyCONMIN.py
+++ b/pyoptsparse/pyCONMIN/pyCONMIN.py
@@ -138,6 +138,8 @@ class CONMIN(Optimizer):
         self.optProb = optProb
         self.optProb.finalizeDesignVariables()
         self.optProb.finalizeConstraints()
+        # Set history/hotstart/coldstart
+        self._setHistory(storeHistory, hotStart)
         self._setInitialCacheValues()
         self._setSens(sens, sensStep, sensMode)
         blx, bux, xs = self._assembleContinuousVariables()
@@ -160,9 +162,6 @@ class CONMIN(Optimizer):
             self.optProb.offset = buc
 
         if self.optProb.comm.rank == 0:
-            # Set history/hotstart/coldstart
-            self._setHistory(storeHistory, hotStart)
-
             # =================================================================
             # CONMIN - Objective/Constraint Values Function
             # =================================================================

--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -167,6 +167,8 @@ class IPOPT(Optimizer):
         self.optProb = optProb
         self.optProb.finalizeDesignVariables()
         self.optProb.finalizeConstraints()
+        # Set history/hotstart
+        self._setHistory(storeHistory, hotStart)
         self._setInitialCacheValues()
         blx, bux, xs = self._assembleContinuousVariables()
         self._setSens(sens, sensStep, sensMode)
@@ -205,9 +207,6 @@ class IPOPT(Optimizer):
             # Now what we need for IPOPT is precisely the .row and
             # .col attributes of the fullJacobian array
             matStruct = (jac["coo"][IROW].copy().astype("int_"), jac["coo"][ICOL].copy().astype("int_"))
-
-            # Set history/hotstart
-            self._setHistory(storeHistory, hotStart)
 
             # Define the 4 call back functions that ipopt needs:
             def eval_f(x, user_data=None):

--- a/pyoptsparse/pyNLPQLP/pyNLPQLP.py
+++ b/pyoptsparse/pyNLPQLP/pyNLPQLP.py
@@ -164,6 +164,8 @@ class NLPQLP(Optimizer):
         self.optProb = optProb
         self.optProb.finalizeDesignVariables()
         self.optProb.finalizeConstraints()
+        # Set history/hotstart/coldstart
+        self._setHistory(storeHistory, hotStart)
         self._setInitialCacheValues()
         self._setSens(sens, sensStep, sensMode)
         blx, bux, xs = self._assembleContinuousVariables()
@@ -190,9 +192,6 @@ class NLPQLP(Optimizer):
             meq = len(tmp0)
 
         if self.optProb.comm.rank == 0:
-            # Set history/hotstart/coldstart
-            self._setHistory(storeHistory, hotStart)
-
             # =================================================================
             # NLPQL - Objective/Constraint Values Function (Real Valued)
             # =================================================================

--- a/pyoptsparse/pyNOMAD/pyNOMAD.py
+++ b/pyoptsparse/pyNOMAD/pyNOMAD.py
@@ -67,6 +67,8 @@ class NOMAD(Optimizer):
         self.optProb = optProb
         self.optProb.finalizeDesignVariables()
         self.optProb.finalizeConstraints()
+        # Set history/hotstart
+        self._setHistory(storeHistory, hotStart)
         self._setInitialCacheValues()
         blx, bux, xs = self._assembleContinuousVariables()
         xs = np.maximum(xs, blx)
@@ -88,9 +90,6 @@ class NOMAD(Optimizer):
             self.optProb.offset = buc
 
         if self.optProb.comm.rank == 0:
-            # Set history/hotstart
-            self._setHistory(storeHistory, hotStart)
-
             # Define the objective function
             # --------------------------------------------------------------
             def objfun(o, x_tuple):

--- a/pyoptsparse/pyNSGA2/pyNSGA2.py
+++ b/pyoptsparse/pyNSGA2/pyNSGA2.py
@@ -126,6 +126,8 @@ class NSGA2(Optimizer):
         self.optProb = optProb
         self.optProb.finalizeDesignVariables()
         self.optProb.finalizeConstraints()
+        # Set history/hotstart
+        self._setHistory(storeHistory, hotStart)
         self._setInitialCacheValues()
 
         blx, bux, xs = self._assembleContinuousVariables()
@@ -153,9 +155,6 @@ class NSGA2(Optimizer):
         f = nsga2.new_doubleArray(len_ff)
 
         if self.optProb.comm.rank == 0:
-            # Set history/hotstart
-            self._setHistory(storeHistory, hotStart)
-
             # Variables Handling
             n = len(xs)
             x = nsga2.new_doubleArray(n)

--- a/pyoptsparse/pyOpt_MPI.py
+++ b/pyoptsparse/pyOpt_MPI.py
@@ -32,6 +32,9 @@ class COMM(object):
     def recv(self, obj=None, source=0, tag=0, status=None):
         return obj
 
+    def Barrier(self):
+        return
+
 
 class myMPI(object):
     def __init__(self):

--- a/pyoptsparse/pyOpt_history.py
+++ b/pyoptsparse/pyOpt_history.py
@@ -454,17 +454,22 @@ class History(object):
         These are all "flat" dictionaries, with simple key:value pairs.
         """
         conDict = {}
-        for con in list(self.optProb.constraints.keys()):
-            # linear constraints are not stored in funcs
-            if not self.optProb.constraints[con].linear:
-                conDict[con] = d["funcs"][con]
-            else:
-                # the linear constraints are removed from optProb so that scaling works
-                # without needing the linear constraints to be present
-                self.optProb.constraints.pop(con)
         objDict = {}
-        for obj in self.objNames:
-            objDict[obj] = d["funcs"][obj]
+        # these require funcs which may not always be there
+        if "funcs" in d.keys():
+            for con in list(self.optProb.constraints.keys()):
+                # linear constraints are not stored in funcs
+                if not self.optProb.constraints[con].linear:
+                    conDict[con] = d["funcs"][con]
+                else:
+                    # the linear constraints are removed from optProb so that scaling works
+                    # without needing the linear constraints to be present
+                    self.optProb.constraints.pop(con)
+
+            for obj in self.objNames:
+                objDict[obj] = d["funcs"][obj]
+
+        # the DVs will always be there
         DVDict = {}
         for DV in self.DVNames:
             DVDict[DV] = d["xuser"][DV]

--- a/pyoptsparse/pyOpt_history.py
+++ b/pyoptsparse/pyOpt_history.py
@@ -493,7 +493,7 @@ class History(object):
             return
         return copy.deepcopy(self.callCounters)
 
-    def getValues(self, names=None, callCounters=None, major=True, scale=False, stack=False):
+    def getValues(self, names=None, callCounters=None, major=True, scale=False, stack=False, allowSens=False):
         """
         Parses an existing history file and returns a data dictionary used to post-process optimization results, containing the requested optimization iteration history.
 
@@ -520,6 +520,10 @@ class History(object):
         stack : bool
             flag to specify whether the DV should be stacked into a single numpy array with
             the key `xuser`, or retain their separate DVGroups.
+
+        allowSens: bool
+            flag to specify whether gradient evaluation iterations are allowed.
+            If true, it is up to the user to ensure that the callCounters specified contain the information requested.
 
         Returns
         -------
@@ -630,7 +634,7 @@ class History(object):
         for i in callCounters:
             if self.pointExists(i):
                 val = self.read(i)
-                if "funcs" in val.keys():  # we have function evaluation
+                if "funcs" in val.keys() or allowSens:  # we have function evaluation
                     if ((major and val["isMajor"]) or not major) and not val["fail"]:
                         conDict, objDict, DVDict = self._processIterDict(val, scale=scale)
                         for name in names:
@@ -658,6 +662,7 @@ class History(object):
                     )
             elif user_specified_callCounter:
                 pyOptSparseWarning(("callCounter {} was not found and is skipped!").format(i))
+
         # reshape lists into numpy arrays
         for name in names:
             # we just stack along axis 0

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -501,7 +501,7 @@ class Optimization(object):
         # Simply add constraint object
         self.constraints[name] = Constraint(name, nCon, linear, wrt, jac, lower, upper, scale)
 
-    def getDVs(self):
+    def getDVs(self, skipFinalization=False):
         """
         Return a dictionary of the design variables. In most common
         usage, this function is not required.
@@ -512,8 +512,9 @@ class Optimization(object):
             The dictionary of variables. This is the same as 'x' that
             would be used to call the user objective function.
         """
-        self.finalizeDesignVariables()
-        self.finalizeConstraints()
+        if not skipFinalization:
+            self.finalizeDesignVariables()
+            self.finalizeConstraints()
         outDVs = {}
         for dvGroup in self.variables:
             nvar = len(self.variables[dvGroup])
@@ -530,7 +531,7 @@ class Optimization(object):
         scaled_DV = self._mapXtoUser_Dict(outDVs)
         return scaled_DV
 
-    def setDVs(self, inDVs):
+    def setDVs(self, inDVs, skipFinalization=False):
         """
         Set one or more groups of design variables from a dictionary.
         In most common usage, this function is not required.
@@ -542,9 +543,11 @@ class Optimization(object):
             variable groups, and the values are the desired design
             variable values for each variable group.
         """
-        self.finalizeDesignVariables()
-        self.finalizeConstraints()
-        x0 = self.getDVs()
+        if not skipFinalization:
+            print("no skip")
+            self.finalizeDesignVariables()
+            self.finalizeConstraints()
+        x0 = self.getDVs(skipFinalization=skipFinalization)
         # overwrite subset of DVs with new values
         for dvGroup in inDVs:
             x0[dvGroup] = inDVs[dvGroup]

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -502,7 +502,7 @@ class Optimization(object):
         # Simply add constraint object
         self.constraints[name] = Constraint(name, nCon, linear, wrt, jac, lower, upper, scale)
 
-    def getDVs(self, skipFinalization=False):
+    def getDVs(self):
         """
         Return a dictionary of the design variables. In most common
         usage, this function is not required.
@@ -513,8 +513,7 @@ class Optimization(object):
             The dictionary of variables. This is the same as 'x' that
             would be used to call the user objective function.
         """
-        if not skipFinalization:
-            self.finalize()
+        self.finalize()
 
         outDVs = {}
         for dvGroup in self.variables:
@@ -532,7 +531,7 @@ class Optimization(object):
         scaled_DV = self._mapXtoUser_Dict(outDVs)
         return scaled_DV
 
-    def setDVs(self, inDVs, skipFinalization=False):
+    def setDVs(self, inDVs):
         """
         Set one or more groups of design variables from a dictionary.
         In most common usage, this function is not required.
@@ -544,9 +543,8 @@ class Optimization(object):
             variable groups, and the values are the desired design
             variable values for each variable group.
         """
-        if not skipFinalization:
-            self.finalize()
-        x0 = self.getDVs(skipFinalization=skipFinalization)
+        self.finalize()
+        x0 = self.getDVs()
         # overwrite subset of DVs with new values
         for dvGroup in inDVs:
             x0[dvGroup] = inDVs[dvGroup]

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -177,7 +177,7 @@ class Optimizer(BaseSolver):
             self.hist = History(storeHistory, flag="n", optProb=self.optProb)
             self.storeHistory = True
 
-            if hotStart is not None:
+            if self.hotStart is not None:
                 for key in ["varInfo", "conInfo", "objInfo", "optProb"]:
                     val = self.hotStart.read(key)
                     if val is not None:

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -5,6 +5,8 @@
 import os
 import time
 import copy
+import tempfile
+import shutil
 import numpy as np
 from .pyOpt_gradient import Gradient
 from .pyOpt_error import Error, pyOptSparseWarning
@@ -150,44 +152,50 @@ class Optimizer(BaseSolver):
         hotStart : str
             Filename for history file for hot start
         """
-        # By default no hot start
-        self.hotStart = None
+        # we have to wrap the whole function
+        # so it's parallel safe
+        if self.optProb.comm.rank == 0:
+            # By default no hot start
+            self.hotStart = None
 
-        # Determine if we want to do a hot start:
-        if hotStart is not None:
-            # Now, if if the hot start file and the history are
-            # the SAME, we don't allow that. We will create a copy
-            # of the hotStart file and use *that* instead.
-            import tempfile
-            import shutil
-
-            if storeHistory == hotStart:
-                if os.path.exists(hotStart):
-                    fname = tempfile.mktemp()
-                    shutil.copyfile(storeHistory, fname)
-                    self.hotStart = History(fname, temp=True, flag="r")
-            else:
-                if os.path.exists(hotStart):
-                    self.hotStart = History(hotStart, temp=False, flag="r")
+            # Determine if we want to do a hot start:
+            if hotStart is not None:
+                # Now, if if the hot start file and the history are
+                # the SAME, we don't allow that. We will create a copy
+                # of the hotStart file and use *that* instead.
+                if storeHistory == hotStart:
+                    if os.path.exists(hotStart):
+                        fname = tempfile.mktemp()
+                        shutil.copyfile(storeHistory, fname)
+                        self.hotStart = History(fname, temp=True, flag="r")
                 else:
-                    pyOptSparseWarning("Hot start file does not exist. Performing a regular start")
+                    if os.path.exists(hotStart):
+                        self.hotStart = History(hotStart, temp=False, flag="r")
+                    else:
+                        pyOptSparseWarning("Hot start file does not exist. Performing a regular start")
 
-        self.storeHistory = False
-        if storeHistory:
-            self.hist = History(storeHistory, flag="n", optProb=self.optProb)
-            self.storeHistory = True
+            self.storeHistory = False
+            if storeHistory:
+                self.hist = History(storeHistory, flag="n", optProb=self.optProb)
+                self.storeHistory = True
 
-            if self.hotStart is not None:
-                # init_DV = self.hotStart.getValues(names=self.hotStart.getDVNames(), callCounters=[0])
-                # print("initDV", init_DV)
-                # self.optProb.setDVs(init_DV, skipFinalization=True)
-                # print("DV set")
-                for key in ["varInfo", "conInfo", "objInfo", "optProb"]:
-                    val = self.hotStart.read(key)
-                    if val is not None:
-                        self.hist.writeData(key, val)
-                self._setMetadata()
-                self.hist.writeData("metadata", self.metadata)
+                if self.hotStart is not None:
+                    # we set the DVs to the _initial_ values of the hotstart history file
+                    # we need major=False here since not all optimizers support major iteration counting
+                    # even though in theory the first call counter should always be major
+                    init_DV = self.hotStart.getValues(
+                        names=self.hotStart.getDVNames(), callCounters=[0], major=False, allowSens=True
+                    )
+                    self.optProb.setDVs(init_DV, skipFinalization=True)
+                    # we also save these metadata values
+                    # into the new history file
+                    for key in ["varInfo", "conInfo", "objInfo", "optProb"]:
+                        val = self.hotStart.read(key)
+                        if val is not None:
+                            self.hist.writeData(key, val)
+                    self._setMetadata()
+                    self.hist.writeData("metadata", self.metadata)
+        self.optProb.comm.Barrier()
 
     def _masterFunc(self, x, evaluate):
         """

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -186,7 +186,7 @@ class Optimizer(BaseSolver):
                     init_DV = self.hotStart.getValues(
                         names=self.hotStart.getDVNames(), callCounters=[0], major=False, allowSens=True
                     )
-                    self.optProb.setDVs(init_DV, skipFinalization=True)
+                    self.optProb.setDVs(init_DV)
                     # we also save these metadata values
                     # into the new history file
                     for key in ["varInfo", "conInfo", "objInfo", "optProb"]:

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -178,6 +178,10 @@ class Optimizer(BaseSolver):
             self.storeHistory = True
 
             if self.hotStart is not None:
+                # init_DV = self.hotStart.getValues(names=self.hotStart.getDVNames(), callCounters=[0])
+                # print("initDV", init_DV)
+                # self.optProb.setDVs(init_DV, skipFinalization=True)
+                # print("DV set")
                 for key in ["varInfo", "conInfo", "objInfo", "optProb"]:
                     val = self.hotStart.read(key)
                     if val is not None:

--- a/pyoptsparse/pyPSQP/pyPSQP.py
+++ b/pyoptsparse/pyPSQP/pyPSQP.py
@@ -148,6 +148,8 @@ class PSQP(Optimizer):
         self.optProb = optProb
         self.optProb.finalizeDesignVariables()
         self.optProb.finalizeConstraints()
+        # Set history/hotstart
+        self._setHistory(storeHistory, hotStart)
         self._setInitialCacheValues()
         self._setSens(sens, sensStep, sensMode)
         blx, bux, xs = self._assembleContinuousVariables()
@@ -191,9 +193,6 @@ class PSQP(Optimizer):
             ic[0 : len(tmp0)] = 5
 
         if self.optProb.comm.rank == 0:
-            # Set history/hotstart
-            self._setHistory(storeHistory, hotStart)
-
             # ======================================================================
             # PSQP - Objective Values Function
             # ======================================================================

--- a/pyoptsparse/pyParOpt/ParOpt.py
+++ b/pyoptsparse/pyParOpt/ParOpt.py
@@ -140,6 +140,8 @@ class ParOpt(Optimizer):
         self.optProb = optProb
         self.optProb.finalizeDesignVariables()
         self.optProb.finalizeConstraints()
+        # Set history/hotstart
+        self._setHistory(storeHistory, hotStart)
         self._setInitialCacheValues()
         self._setSens(sens, sensStep, sensMode)
         blx, bux, xs = self._assembleContinuousVariables()
@@ -161,8 +163,6 @@ class ParOpt(Optimizer):
             self.optProb.offset = buc
 
         if self.optProb.comm.rank == 0:
-            # Set history/hotstart
-            self._setHistory(storeHistory, hotStart)
 
             class Problem(_ParOpt.Problem):
                 def __init__(self, ptr, n, m, xs, blx, bux):

--- a/pyoptsparse/pySLSQP/pySLSQP.py
+++ b/pyoptsparse/pySLSQP/pySLSQP.py
@@ -147,6 +147,8 @@ class SLSQP(Optimizer):
         self.optProb = optProb
         self.optProb.finalizeDesignVariables()
         self.optProb.finalizeConstraints()
+        # Set history/hotstart
+        self._setHistory(storeHistory, hotStart)
         self._setInitialCacheValues()
         self._setSens(sens, sensStep, sensMode)
         blx, bux, xs = self._assembleContinuousVariables()
@@ -173,9 +175,6 @@ class SLSQP(Optimizer):
             meq = len(tmp0)
 
         if self.optProb.comm.rank == 0:
-            # Set history/hotstart
-            self._setHistory(storeHistory, hotStart)
-
             # =================================================================
             # SLSQP - Objective/Constraint Values Function
             # =================================================================

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -273,7 +273,8 @@ class SNOPT(Optimizer):
         self.optProb = optProb
         self.optProb.finalizeDesignVariables()
         self.optProb.finalizeConstraints()
-
+        # Set history/hotstart
+        self._setHistory(storeHistory, hotStart)
         self._setInitialCacheValues()
         self._setSens(sens, sensStep, sensMode)
         blx, bux, xs = self._assembleContinuousVariables()
@@ -452,10 +453,6 @@ class SNOPT(Optimizer):
             nS = np.array([0], np.intc)
             ninf = np.array([0], np.intc)
             sinf = np.array([0.0], np.float)
-
-            # Set history/hotstart
-            self._setHistory(storeHistory, hotStart)
-            print(self.optProb.getDVs(skipFinalization=True))
 
             # The snopt c interface
             timeA = time.time()

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -456,6 +456,7 @@ class SNOPT(Optimizer):
 
             # Set history/hotstart
             self._setHistory(storeHistory, hotStart)
+            print(self.optProb.getDVs(skipFinalization=True))
 
             # The snopt c interface
             timeA = time.time()

--- a/test/test_hs015.py
+++ b/test/test_hs015.py
@@ -177,7 +177,6 @@ class TestHS15(unittest.TestCase):
 
         # this check is only used for optimizers that guarantee '0' and 'last' contain funcs
         if optimizer in ["SNOPT", "PSQP"]:
-            print(hist.read("last"))
             val = hist.getValues(callCounters=["0", "last"], stack=True)
             self.assertEqual(val["isMajor"].size, 2)
             self.assertTrue(val["isMajor"][0])  # the first callCounter must be a major iteration

--- a/test/test_hs015.py
+++ b/test/test_hs015.py
@@ -200,6 +200,11 @@ class TestHS15(unittest.TestCase):
         # we should have zero actual function/gradient evaluations
         self.assertEqual(self.nf, 0)
         self.assertEqual(self.ng, 0)
+        # another test with hotstart, this time with a non-existing history file
+        self.optimize(optName, tol, storeHistory=True, hotStart="notexisting.hst", optOptions=optOptions)
+        self.assertGreater(self.nf, 0)
+        self.assertGreater(self.ng, 0)
+        self.check_hist_file(optName, tol)
         # final test with hotstart, this time with a different storeHistory
         self.optimize(
             optName,

--- a/test/test_hs015.py
+++ b/test/test_hs015.py
@@ -190,7 +190,7 @@ class TestHS15(unittest.TestCase):
         In this process, it will check various combinations of storeHistory and hotStart filenames.
         It will also call `check_hist_file` after the first optimization.
         """
-        self.optimize(optName, tol, storeHistory=True, optOptions=optOptions, x0=[0.0, 0.0])
+        self.optimize(optName, tol, storeHistory=True, optOptions=optOptions, x0=[-2.01, 1.01])
         self.assertGreater(self.nf, 0)
         self.assertGreater(self.ng, 0)
         self.check_hist_file(optName, tol)

--- a/test/test_hs015.py
+++ b/test/test_hs015.py
@@ -190,7 +190,7 @@ class TestHS15(unittest.TestCase):
         In this process, it will check various combinations of storeHistory and hotStart filenames.
         It will also call `check_hist_file` after the first optimization.
         """
-        self.optimize(optName, tol, storeHistory=True, optOptions=optOptions, x0=[-2.01, 1.01])
+        self.optimize(optName, tol, storeHistory=True, optOptions=optOptions, x0=[-2.001, 1.001])
         self.assertGreater(self.nf, 0)
         self.assertGreater(self.ng, 0)
         self.check_hist_file(optName, tol)

--- a/test/test_hs015.py
+++ b/test/test_hs015.py
@@ -48,7 +48,7 @@ class TestHS15(unittest.TestCase):
         fail = False
         return funcsSens, fail
 
-    def optimize(self, optName, tol, optOptions={}, storeHistory=False, hotStart=None):
+    def optimize(self, optName, tol, optOptions={}, storeHistory=False, hotStart=None, x0=[-2, 1.0]):
         self.nf = 0  # number of function evaluations
         self.ng = 0  # number of gradient evaluations
         # Optimization Object
@@ -57,8 +57,7 @@ class TestHS15(unittest.TestCase):
         # Design Variables
         lower = [-5.0, -5.0]
         upper = [0.5, 5.0]
-        value = [-2, 1.0]
-        optProb.addVarGroup("xvars", 2, lower=lower, upper=upper, value=value)
+        optProb.addVarGroup("xvars", 2, lower=lower, upper=upper, value=x0)
 
         # Constraints
         lower = [1.0, 0.0]
@@ -185,7 +184,7 @@ class TestHS15(unittest.TestCase):
         In this process, it will check various combinations of storeHistory and hotStart filenames.
         It will also call `check_hist_file` after the first optimization.
         """
-        self.optimize(optName, tol, storeHistory=True, optOptions=optOptions)
+        self.optimize(optName, tol, storeHistory=True, optOptions=optOptions, x0=[0.0, 0.0])
         self.assertGreater(self.nf, 0)
         self.assertGreater(self.ng, 0)
         self.check_hist_file(optName, tol)

--- a/test/test_hs015.py
+++ b/test/test_hs015.py
@@ -176,7 +176,8 @@ class TestHS15(unittest.TestCase):
         val = hist.getValues()
 
         # this check is only used for optimizers that guarantee '0' and 'last' contain funcs
-        if optimizer in ["SNOPT", "SLSQP", "PSQP"]:
+        if optimizer in ["SNOPT", "PSQP"]:
+            print(hist.read("last"))
             val = hist.getValues(callCounters=["0", "last"], stack=True)
             self.assertEqual(val["isMajor"].size, 2)
             self.assertTrue(val["isMajor"][0])  # the first callCounter must be a major iteration
@@ -206,6 +207,7 @@ class TestHS15(unittest.TestCase):
         self.assertEqual(self.nf, 0)
         self.assertEqual(self.ng, 0)
         # another test with hotstart, this time with a non-existing history file
+        # this will perform a cold start
         self.optimize(optName, tol, storeHistory=True, hotStart="notexisting.hst", optOptions=optOptions)
         self.assertGreater(self.nf, 0)
         self.assertGreater(self.ng, 0)
@@ -270,7 +272,7 @@ class TestHS15(unittest.TestCase):
 
     def test_psqp(self):
         optOptions = {"IFILE": "hs015_PSQP.out"}
-        self.optimize_with_hotstart("PSQP", 1e-12, optOptions=optOptions)
+        self.optimize_with_hotstart("PSQP", 5e-12, optOptions=optOptions)
 
 
 if __name__ == "__main__":

--- a/test/test_rosenbrock.py
+++ b/test/test_rosenbrock.py
@@ -148,7 +148,7 @@ class TestRosenbrock(unittest.TestCase):
             self.assertIn(key, iterKeys)
 
         # this check is only used for optimizers that guarantee '0' and 'last' contain funcs
-        if optimizer in ["SNOPT", "SLSQP", "PSQP"]:
+        if optimizer in ["SNOPT", "PSQP"]:
             val = hist.getValues(callCounters=["0", "last"], stack=True)
             self.assertEqual(val["isMajor"].size, 2)
             self.assertTrue(val["isMajor"][0])  # the first callCounter must be a major iteration


### PR DESCRIPTION
## Purpose
This PR addresses several issues with hotstart
- closes #208
- closes #209

In this process, we've had to make the following changes:
- move `setHistory` to outside of the comm split for all optimizers. This allows us to set the initial DVs into the optProb before it's parsed to generate the numpy arrays for each optimizer
- wrap `setHistory` with MPI to ensure only a single proc is reading/writing to the history file
- updated `getValues` and the History class in general to allow accessing iterations which are not analysis. For some reason, certain optimizers (IPOPT in this case) will have the initial evaluation be a gradient one, I have no idea why. Since we only want the initial DVs this doesn't matter, but the code had to be updated to handle this.

Remaining TODOs:
- [ ] add documentation on how hotstart works (I will work with @marcomangano to address this)

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
We added new tests starting from perturbed DVs, and ensuring that the hotstart completed successfully without us having to manually set the DVs.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
