### PR TITLE
Add back the finalize functions but throw a deprecation warning

### DIFF
--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -6,6 +6,7 @@ import copy
 import os
 from collections import OrderedDict
 from sqlitedict import SqliteDict
+import warnings
 
 # =============================================================================
 # External Python modules
@@ -801,6 +802,12 @@ class Optimization(object):
             self._finalizeConstraints()
             self.finalized = True
 
+    def finalizeDesignVariables(self):
+        warnings.warn(
+            "finalizeDesignVariables() is deprecated, use _finalizeDesignVariables() instead.", DeprecationWarning
+        )
+        self._finalizeDesignVariables()
+
     def _finalizeDesignVariables(self):
         """
         Communicate design variables potentially from different
@@ -824,6 +831,10 @@ class Optimization(object):
             self.dvOffset[dvGroup] = [dvCounter, dvCounter + n, self.variables[dvGroup][0].scalar]
             dvCounter += n
         self.ndvs = dvCounter
+
+    def finalizeConstraints(self):
+        warnings.warn("finalizeConstraints() is deprecated, use _finalizeConstraints() instead.", DeprecationWarning)
+        self._finalizeConstraints()
 
     def _finalizeConstraints(self):
         """


### PR DESCRIPTION
## Purpose
This PR adds back the functions that were renamed in #221, as that technically broke backwards compatibility. We now throw a deprecation warning if the user tries to use those functions, and they will be removed in a future release.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
N/A

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
