### PR TITLE
Made stored function values real

### DIFF
--- a/pyoptsparse/pyOpt_gradient.py
+++ b/pyoptsparse/pyOpt_gradient.py
@@ -168,7 +168,7 @@ class Gradient(object):
 
         if self.sensMode == "pgc":
             # We just mpi_reduce to the root with sum. This uses the
-            # efficent numpy versions
+            # efficient numpy versions
             self.comm.Reduce(gobj.copy(), gobj, op=MPI.SUM, root=0)
             self.comm.Reduce(gcon.copy(), gcon, op=MPI.SUM, root=0)
 
@@ -179,18 +179,18 @@ class Gradient(object):
 
         # Finally, we have to convert everything **back** to a
         # dictionary so the rest of the code works:
-        funcs = {}
+        funcsSens = {}
         for objKey in self.optProb.objectives:
-            funcs[objKey] = {}
+            funcsSens[objKey] = {}
             for dvGroup in self.optProb.variables:
                 ss = self.optProb.dvOffset[dvGroup]
-                funcs[objKey][dvGroup] = gobj[ss[0] : ss[1]]
+                funcsSens[objKey][dvGroup] = gobj[ss[0] : ss[1]]
 
         for conKey in self.optProb.constraints:
             con = self.optProb.constraints[conKey]
-            funcs[conKey] = {}
+            funcsSens[conKey] = {}
             for dvGroup in self.optProb.variables:
                 ss = self.optProb.dvOffset[dvGroup]
-                funcs[conKey][dvGroup] = gcon[con.rs : con.re, ss[0] : ss[1]]
+                funcsSens[conKey][dvGroup] = gcon[con.rs : con.re, ss[0] : ss[1]]
 
-        return funcs, masterFail
+        return funcsSens, masterFail

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -1651,10 +1651,7 @@ class Optimization(object):
         fmt = "    {0:>7d}  {1:{width}s}   {2:>14.6E}   {3:>14.6E}\n"
         for idx, name in enumerate(self.objectives):
             obj = self.objectives[name]
-            value = obj.value
-            if np.iscomplexobj(value):
-                value = value.real
-            text += fmt.format(idx, obj.name, value, obj.optimum, width=num_c)
+            text += fmt.format(idx, obj.name, obj.value, obj.optimum, width=num_c)
 
         # Find the longest name in the variables
         num_c = 0
@@ -1672,8 +1669,6 @@ class Optimization(object):
             for var in self.variables[varname]:
                 if var.type in ["c", "i"]:
                     value = var.value
-                    if np.iscomplexobj(value):
-                        value = value.real
                     lower = var.lower if var.lower is not None else -1.0e20
                     upper = var.upper if var.upper is not None else 1.0e20
                     status = ""
@@ -1734,8 +1729,6 @@ class Optimization(object):
                     lower = c.lower[j] if c.lower[j] is not None else -1.0e20
                     upper = c.upper[j] if c.upper[j] is not None else 1.0e20
                     value = c.value[j]
-                    if np.iscomplexobj(value):
-                        value = value.real
                     status = ""
                     typ = "e" if j in c.equalityConstraints["ind"] else "i"
                     if typ == "e":

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -1137,7 +1137,7 @@ class Optimization(object):
                 except ValueError:
                     raise Error("The objective return value, '%s' must be a scalar!" % objKey)
                 # Store objective for printing later
-                self.objectives[objKey].value = f
+                self.objectives[objKey].value = np.real(f)
                 fobj.append(f)
             else:
                 raise Error("The key for the objective, '%s' was not found." % objKey)
@@ -1232,7 +1232,7 @@ class Optimization(object):
                     )
 
                 # Store constraint values for printing later
-                con.value = copy.copy(c)
+                con.value = np.real(copy.copy(c))
             else:
                 raise Error("No constraint values were found for the constraint '%s'." % iCon)
 

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -76,7 +76,8 @@ class Optimization(object):
         # constraints
         self.ndvs = None
         self.conScale = None
-        self.nCon = None
+        self.nCon = 0
+        self.nObj = 0
         self.invXScale = None
         self.xOffset = None
         self.linearJacobian = None
@@ -861,7 +862,6 @@ class Optimization(object):
         # ----------------------------------------------------
 
         # Determine number of constraints
-        self.nCon = 0
         for iCon in self.constraints:
             self.nCon += self.constraints[iCon].ncon
 
@@ -904,6 +904,7 @@ class Optimization(object):
         # --------------------------------------
         for idx, objKey in enumerate(self.objectives):
             self.objectiveIdx[objKey] = idx
+            self.nObj += 1
 
         # ---------------------------------------------
         # Step 4. Final Jacobian for linear constraints
@@ -1362,9 +1363,7 @@ class Optimization(object):
         """
 
         dvGroups = set(self.variables.keys())
-
-        nobj = len(self.objectives)
-        gobj = np.zeros((nobj, self.ndvs))
+        gobj = np.zeros((self.nObj, self.ndvs))
 
         iObj = 0
         for objKey in self.objectives.keys():

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -358,7 +358,12 @@ class Optimizer(BaseSolver):
 
                 self.userObjTime += time.time() - timeA
                 self.userObjCalls += 1
-                # User values stored is immediately
+
+                # Discard zero imaginary components in funcs
+                for key, val in funcs.items():
+                    funcs[key] = np.real(val)
+
+                # Store user values
                 self.cache["funcs"] = copy.deepcopy(funcs)
 
                 # Process constraints/objectives
@@ -401,7 +406,12 @@ class Optimizer(BaseSolver):
 
                 self.userObjTime += time.time() - timeA
                 self.userObjCalls += 1
-                # User values stored is immediately
+
+                # Discard zero imaginary components in funcs
+                for key, val in funcs.items():
+                    funcs[key] = np.real(val)
+
+                # Store user values
                 self.cache["funcs"] = copy.deepcopy(funcs)
 
                 # Process constraints/objectives
@@ -456,7 +466,7 @@ class Optimizer(BaseSolver):
                 self.userSensTime += time.time() - timeA
                 self.userSensCalls += 1
 
-                # User values are stored is immediately
+                # User values are stored immediately
                 self.cache["funcsSens"] = copy.deepcopy(funcsSens)
 
                 # Process objective gradient for optimizer
@@ -510,7 +520,8 @@ class Optimizer(BaseSolver):
 
                 self.userSensTime += time.time() - timeA
                 self.userSensCalls += 1
-                # User values stored is immediately
+
+                # User values are stored immediately
                 self.cache["funcsSens"] = copy.deepcopy(funcsSens)
 
                 # Process objective gradient for optimizer

--- a/test/test_tp109.py
+++ b/test/test_tp109.py
@@ -142,14 +142,22 @@ class TestTP109(unittest.TestCase):
         else:
             assert_allclose(sol.fStar, 0.536206927538e04, atol=tol, rtol=tol)
 
+        # Check that the function values in the solution are real
+        self.assertTrue(np.isrealobj(sol.objectives["obj"].value))
+        self.assertTrue(np.isrealobj(sol.constraints["con"].value))
+
     def test_snopt(self):
         name = "tp109_snopt.hst"
         self.optimize("SNOPT", 1e-7, storeHistory=name)
         hist = History(name)
         self.assertNotIn("lin_con", hist.getConNames())
         self.assertNotIn("lin_con", hist.getConInfo())
-        hist.getValues()
+        val = hist.getValues()
         hist.getValues(scale=True)
+
+        # Check that the function values in the history are real
+        self.assertTrue(np.isrealobj(val["obj"]))
+        self.assertTrue(np.isrealobj(val["con"]))
 
     def test_slsqp(self):
         self.optimize("slsqp", 1e-7)


### PR DESCRIPTION
## Purpose
When `objFun` is defined as a complex function to work with the complex-step derivative, there are two separate cases where complex values leak into the stored function values:

1) In the solution object. This was previously addressed in #102 but only for printing. I reverted this commit and changed `processObjtoVec` and `processContoVec` so that the stored value is real instead.

2) In the history file. I fixed this by casting `funcs` to real before they are cached.

Closes #76


## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
