### PR TITLE
Fix counters bug

### DIFF
--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -836,7 +836,9 @@ class Optimization(object):
         This should not be called directly. Instead, call self.finalize()
         to ensure that both design variables and constraints are properly finalized.
         """
-
+        # reset these counters
+        self.nObj = 0
+        self.nCon = 0
         # First thing we need is to determine the consistent set of
         # constraints from all processors
         self.constraints = self._reduceDict(self.constraints)

--- a/test/test_optProb.py
+++ b/test/test_optProb.py
@@ -241,6 +241,26 @@ class TestOptProb(unittest.TestCase):
                 scale = np.hstack(self.conScale)
             assert_allclose(val_opt, val_user * scale)
 
+    def test_finalize(self):
+        """
+        Check that multiple finalize calls don't mess up the optProb
+        """
+        self.setup_optProb(nObj=1, nDV=[4, 8], nCon=[2, 3], xScale=[1.0, 1.0], conScale=[1.0, 1.0], offset=[0, 0])
+        self.assert_optProb_size(1, 12, 5)
+        self.optProb.addObj("obj2")
+        self.assert_optProb_size(2, 12, 5)
+        self.optProb.addVar("DV2")
+        self.assert_optProb_size(2, 13, 5)
+        self.optProb.addCon("CON2")
+        self.assert_optProb_size(2, 13, 6)
+
+    def assert_optProb_size(self, nObj, nDV, nCon):
+        """Checks that nObj, nDV adn nCon are correct for self.optProb"""
+        self.optProb.finalize()
+        self.assertEqual(self.optProb.nObj, nObj)
+        self.assertEqual(self.optProb.nCon, nCon)
+        self.assertEqual(self.optProb.ndvs, nDV)
+
     def assert_dict_allclose(self, actual, desired, atol=tol, rtol=tol):
         """
         Simple assert for two flat dictionaries, where the values are

--- a/test/test_optProb.py
+++ b/test/test_optProb.py
@@ -255,7 +255,7 @@ class TestOptProb(unittest.TestCase):
         self.assert_optProb_size(2, 13, 6)
 
     def assert_optProb_size(self, nObj, nDV, nCon):
-        """Checks that nObj, nDV adn nCon are correct for self.optProb"""
+        """Checks that nObj, nDV and nCon are correct for self.optProb"""
         self.optProb.finalize()
         self.assertEqual(self.optProb.nObj, nObj)
         self.assertEqual(self.optProb.nCon, nCon)


### PR DESCRIPTION
## Purpose
In #225, a bug was introduced whereby `self.nObj` was set to 0 in the init, and `finalize()` would increment this counter. However, multiple invocations of `finalize()` would not reset it to zero first, resulting in erroneous `nObj` values. This PR resets these counters so that `finalze()` is once again safe for multiple invocations. Note that this is only relevant if the user has changed `optProb` in between, since otherwise `finalize()` would be skipped altogether via the `self.finalized` flag check.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
None, since we never tested against this use case.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
