### PR TITLE
Revert IPOPT print level to optimizer default

### DIFF
--- a/doc/optimizers/IPOPT_options.yaml
+++ b/doc/optimizers/IPOPT_options.yaml
@@ -1,5 +1,3 @@
-print_level:
-  desc: Printing level
 output_file:
   desc: The name of the output file from IPOPT
 option_file_name:

--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -80,7 +80,6 @@ class IPOPT(Optimizer):
     @staticmethod
     def _getDefaultOptions():
         defOpts = {
-            "print_level": [int, 0],
             "output_file": [str, "IPOPT.out"],
             "option_file_name": [str, "IPOPT_options.opt"],
             "linear_solver": [str, "mumps"],


### PR DESCRIPTION
## Purpose
Removing the default pyIPOPT `print_level: 0` option and revert to IPOPT default (`print_level: 5`). 
This provides a more verbose and useful output on both the terminal and the `.out` file.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
Verified locally by multiple users

## Checklist

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
