### PR TITLE
Update IPOPT default options

### DIFF
--- a/doc/optimizers/IPOPT_options.yaml
+++ b/doc/optimizers/IPOPT_options.yaml
@@ -4,8 +4,6 @@ file_print_level:
   desc: Printing level for the output file
 output_file:
   desc: The name of the output file from IPOPT
-option_file_name:
-  desc: The name of the options file passed to IPOPT
 print_user_options:
   desc: Whether to print the user-modified options
 linear_solver:

--- a/doc/optimizers/IPOPT_options.yaml
+++ b/doc/optimizers/IPOPT_options.yaml
@@ -1,8 +1,14 @@
 print_level:
   desc: Printing level
+file_print_level:
+  desc: Printing level for the output file
 output_file:
   desc: The name of the output file from IPOPT
 option_file_name:
   desc: The name of the options file passed to IPOPT
+print_user_options:
+  desc: Whether to print the user-modified options
 linear_solver:
   desc: The linear solver used.
+sb:
+  desc: This is an undocumented option which suppresses the IPOPT header from being printed to screen every time.

--- a/doc/optimizers/IPOPT_options.yaml
+++ b/doc/optimizers/IPOPT_options.yaml
@@ -1,3 +1,5 @@
+print_level:
+  desc: Printing level
 output_file:
   desc: The name of the output file from IPOPT
 option_file_name:

--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -81,6 +81,9 @@ class IPOPT(Optimizer):
     def _getDefaultOptions():
         defOpts = {
             "print_level": [int, 0],
+            "file_print_level": [int, 5],
+            "sb": [str, "yes"],
+            "print_user_options": [str, "yes"],
             "output_file": [str, "IPOPT.out"],
             "option_file_name": [str, "IPOPT_options.opt"],
             "linear_solver": [str, "mumps"],

--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -80,6 +80,7 @@ class IPOPT(Optimizer):
     @staticmethod
     def _getDefaultOptions():
         defOpts = {
+            "print_level": [int, 0],
             "output_file": [str, "IPOPT.out"],
             "option_file_name": [str, "IPOPT_options.opt"],
             "linear_solver": [str, "mumps"],

--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -85,7 +85,6 @@ class IPOPT(Optimizer):
             "sb": [str, "yes"],
             "print_user_options": [str, "yes"],
             "output_file": [str, "IPOPT.out"],
-            "option_file_name": [str, "IPOPT_options.opt"],
             "linear_solver": [str, "mumps"],
         }
         return defOpts

--- a/test/test_hs071.py
+++ b/test/test_hs071.py
@@ -248,7 +248,7 @@ class TestHS71(unittest.TestCase):
         self.assertEqual(sol.optInform["value"], 1)
 
     def test_ipopt(self):
-        optOptions = {"print_level": 5, "output_file": "hs071_IPOPT.out"}
+        optOptions = {"output_file": "hs071_IPOPT.out"}
         sol = self.optimize("ipopt", 1e-6, optOptions=optOptions)
         self.assertEqual(sol.optInform["value"], 0)
         self.assertEqual(sol.optInform["text"], "Solve Succeeded")


### PR DESCRIPTION
## Purpose
This reverts PR #233, and updates a few default IPOPT options:
- `print_level` is set to 0 again to suppress printing to screen
- `file_print_level` is set to 5 to print iterations to file (this is necessary because we set `print_level` to 0 and IPOPT automatically sets `file_print_level` to that)
- `print_user_options` is set to `yes` to always print a list of user-modified options
- `sb` set to `yes` to suppress printing of the IPOPT banner. Note that this is an undocumented option
- `option_file_name` has been removed since the default option is sufficient. This also gets rid of the annoying "Using option file "IPOPT_options.opt"` messages.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
All tests pass, indicating that the options are being set correctly. I also confirmed locally that this does indeed suppress printing to screen, and that the expected information is in the IPOPT output file.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
