### PR TITLE
Changed DeprecationWarning to the default warning

### DIFF
--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -230,7 +230,7 @@ class Optimization(object):
         if "type" in kwargs:
             varType = kwargs["type"]
             # but we also throw a deprecation warning
-            warnings.warn("The argument `type=` is deprecated. Use `varType` in the future.", DeprecationWarning)
+            warnings.warn("The argument `type=` is deprecated. Use `varType` in the future.")
         # Check that the type is ok
         if varType not in ["c", "i", "d"]:
             raise Error("Type must be one of 'c' for continuous, 'i' for integer or 'd' for discrete.")
@@ -816,9 +816,7 @@ class Optimization(object):
             self.finalized = True
 
     def finalizeDesignVariables(self):
-        warnings.warn(
-            "finalizeDesignVariables() is deprecated, use _finalizeDesignVariables() instead.", DeprecationWarning
-        )
+        warnings.warn("finalizeDesignVariables() is deprecated, use _finalizeDesignVariables() instead.")
         self._finalizeDesignVariables()
 
     def _finalizeDesignVariables(self):
@@ -846,7 +844,7 @@ class Optimization(object):
         self.ndvs = dvCounter
 
     def finalizeConstraints(self):
-        warnings.warn("finalizeConstraints() is deprecated, use _finalizeConstraints() instead.", DeprecationWarning)
+        warnings.warn("finalizeConstraints() is deprecated, use _finalizeConstraints() instead.")
         self._finalizeConstraints()
 
     def _finalizeConstraints(self):


### PR DESCRIPTION
## Purpose
Python by default does not show `DeprecationWarning` for most scenarios, so I switched warnings to use the default `UserWarning` which is by default shown.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
