### PR TITLE
Fixed IPOPT history recording

### DIFF
--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -217,6 +217,12 @@ class Optimizer(BaseSolver):
             values is required on return
         """
 
+        # print(self.callCounter, evaluate)
+
+        # if self.name == "IPOPT" and ("fcon" in evaluate or "gcon" in evaluate):
+        #     if self.callCounter >= 3:
+        #         self.callCounter -= 1
+
         # We are hot starting, we should be able to read the required
         # information out of the hot start file, process it and then
         # fire it back to the specific optimizer
@@ -233,6 +239,12 @@ class Optimizer(BaseSolver):
 
                 # Validated x-point point to use:
                 xuser_vec = self.optProb._mapXtoUser(x)
+
+                print("call counter", self.callCounter)
+                if not (np.isclose(xuser_vec, xuser_ref, rtol=EPS, atol=EPS).all()):
+                    aaaaaaaa = 0
+                    pass
+
                 if np.isclose(xuser_vec, xuser_ref, rtol=EPS, atol=EPS).all():
 
                     # However, we may need a sens that *isn't* in the


### PR DESCRIPTION
## Purpose
Addresses #182 . This fixes the bug that IPOPT history files constraint duplicated entries in a _hacky_ way.

### Note
It basically checks if the current call is already recorded or not based on `x` values. If the current `x` is identical to the previous `x` at which we wrote the history, then we don't write the history.
I first wanted to check that based on the type of the call (i.e. constraints or objective), then write the history only when it is an objective (or its gradient) call. This worked fine for cold starts and the code would've been much cleaner, but it is problematic when we parse the history for hot starts.
When we don't record the constraint calls, during the hot start, we need to get info from an adjacent call counter (which is the objective call we recorded at the same `x`). But the problem is that we don't know which adjacent call counter (+1 or -1) we should refer, because we don't know which function (objective or constraints) IPOPT calls first at each iteration. It sometimes calls the objective first, but the other times it calls the constraints first. That's why we have to rely on`x` values.

Since the code is hacky, it might be better to keep the history file unfixed, but delete the duplicated entries in OptView or somewhere. What do you think @nwu63 @A-Gray-94 ?

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
This is the history file of `test_hs015.py`. It matches what IPOPT claims (12 function and 11 jacobian evaluations). The previous behavior can be found in #238 .
![Screenshot from 2021-04-25 23-20-56](https://user-images.githubusercontent.com/49300827/116026860-862a9000-a621-11eb-832b-7e37a33c2cdd.png)


## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
