### PR TITLE
Remove misleading `Optimum` key from terminal printout

### DIFF
--- a/.github/test_real.sh
+++ b/.github/test_real.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 set -e
-testflo --pre_announce -v
+if [[ $IMAGE == "public" ]]; then
+    testflo --pre_announce -v
+else
+    # all tests should pass on private
+    testflo --pre_announce -v --disallow_skipped
+fi

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -101,8 +101,8 @@ which produces the following table::
 
 
       Objectives
-         Index  Name            Value          Optimum
-            0  obj     0.000000E+00     0.000000E+00
+         Index  Name            Value
+            0  obj     0.000000E+00
 
       Variables (c - continuous, i - integer, d - discrete)
          Index  Name      Type      Lower Bound            Value      Upper Bound     Status
@@ -158,8 +158,8 @@ which produces the following output::
 
 
       Objectives
-         Index  Name            Value          Optimum
-            0  obj    -3.456000E+03     0.000000E+00
+         Index  Name            Value
+            0  obj    -3.456000E+03
 
       Variables (c - continuous, i - integer, d - discrete)
          Index  Name      Type      Lower Bound            Value      Upper Bound     Status

--- a/pyoptsparse/pyOpt_objective.py
+++ b/pyoptsparse/pyOpt_objective.py
@@ -23,15 +23,14 @@ class Objective(object):
         """
         self.name = name
         self.value = 0.0
-        self.optimum = 0.0
         self.scale = scale
 
     def __str__(self):
         """
         Structured Print of Objective
         """
-        res = "        Name        Value        Optimum\n"
+        res = "        Name        Value\n"
         res += "	 " + str(self.name).center(9)
-        res += "%12g  %12g\n" % (np.real(self.value), np.real(self.optimum))
+        res += "%12g\n" % (np.real(self.value))
 
         return res

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -1660,12 +1660,12 @@ class Optimization(object):
         text += "\n   Objectives\n"
 
         num_c = max([len(obj) for obj in self.objectives])
-        fmt = "    {0:>7s}  {1:{width}s}   {2:>14s}   {3:>14s}\n"
-        text += fmt.format("Index", "Name", "Value", "Optimum", width=num_c)
-        fmt = "    {0:>7d}  {1:{width}s}   {2:>14.6E}   {3:>14.6E}\n"
+        fmt = "    {0:>7s}  {1:{width}s}   {2:>14s}\n"
+        text += fmt.format("Index", "Name", "Value", width=num_c)
+        fmt = "    {0:>7d}  {1:{width}s}   {2:>14.6E}\n"
         for idx, name in enumerate(self.objectives):
             obj = self.objectives[name]
-            text += fmt.format(idx, obj.name, obj.value, obj.optimum, width=num_c)
+            text += fmt.format(idx, obj.name, obj.value, width=num_c)
 
         # Find the longest name in the variables
         num_c = 0


### PR DESCRIPTION
## Purpose
The current Objective class has an `optimum` attribute that is never used or updated, but is printed on terminal when `optProb` or the final solution objects are printed. As this is misleading and unnecessary, I just removed it from the code.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
Tested locally and the extra item does not appear anymore.

## Checklist

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
