### PR TITLE
remove deepcopy of sensitivity dict to improve performance

### DIFF
--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -468,7 +468,9 @@ class Optimizer(BaseSolver):
                 self.userSensCalls += 1
 
                 # User values are stored immediately
-                self.cache["funcsSens"] = copy.deepcopy(funcsSens)
+                # deepcopy of the sens dictionary is slow, so just reference it
+                # It shouldn't be modified until the next sensitivity call.
+                self.cache["funcsSens"] = funcsSens
 
                 # Process objective gradient for optimizer
                 gobj = self.optProb.processObjectiveGradient(funcsSens)
@@ -521,7 +523,7 @@ class Optimizer(BaseSolver):
                 self.userSensCalls += 1
 
                 # User values are stored immediately
-                self.cache["funcsSens"] = copy.deepcopy(funcsSens)
+                self.cache["funcsSens"] = funcsSens
 
                 # Process objective gradient for optimizer
                 gobj = self.optProb.processObjectiveGradient(funcsSens)


### PR DESCRIPTION
## Purpose

While doing some profiling, I discovered that the deepcopy of the sensitivity dictionary during `_masterFunc2` is a rather slow operation. On my problem, an 11.5 second optimization was spending 1.95 seconds in that deepcopy. Removing it and replacing with just a reference dropped my runtime to 9.5 seconds.  Obviously this is peanuts if you are optimizing a problem with long objective and gradient compute times, but if you are performing many optimizations on small fast problems, that extra couple of seconds per run is important.

I think replacing with a reference is safe in most cases, if not all. The user-provided (or openmdao-provided) gradient function assembles that dictionary, and I can't think of any reasonable cases where something is going to change those values before the next gradient request.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing

This is just a performance change, so I verified that existing tests pass.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
