### PR TITLE
Fixed  an issue for the save_tec func in OptView

### DIFF
--- a/pyoptsparse/postprocessing/OptView.py
+++ b/pyoptsparse/postprocessing/OptView.py
@@ -747,7 +747,7 @@ class Display(OVBaseClass):
             for name in values:
                 dat[name] = self.var_data[name]
 
-        keys = dat.keys()
+        keys = list(dat.keys())
 
         num_vars = len(keys)
         num_iters = len(dat[keys[0]])


### PR DESCRIPTION
Choosing the save tec file button will not work for OptView.py. It returned a "dict_keys object is not subscriptable" error. Need to convert the dict_keys to a list.

## Purpose
Fixed a bug for the save_tec function in OptView

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
