### PR TITLE
Suppress SNOPT minor print log

### DIFF
--- a/doc/optimizers/SNOPT_options.yaml
+++ b/doc/optimizers/SNOPT_options.yaml
@@ -7,8 +7,11 @@ iSumm:
 Print file:
   desc: Print file name
 
-Summary file: 
+Summary file:
   desc: Summary file name
+
+Minor print level:
+  desc: Minor iterations print level
 
 Start:
   desc: This value is directly passed to the SNOPT kernel, and will be overwritten if another option, e.g. ``Cold start`` is supplied, in accordance with SNOPT options precedence.
@@ -46,7 +49,6 @@ Total integer workspace:
     If SNOPT determines that the default value is too small, the Python wrapper will overwrite the defaults with estimates for the required workspace lengths from SNOPT and initialize the optimizer for a second time.
     SNOPT might still exit with ``82``, ``83``, or ``84``, but this should automate the storage allocation for most cases.
     User-specified values are not overwritten.
-    
 
 Total real workspace:
   desc: >
@@ -55,7 +57,6 @@ Total real workspace:
     If SNOPT determines that the default value is too small, the Python wrapper will overwrite the defaults with estimates for the required workspace lengths from SNOPT and initialize the optimizer for a second time.
     SNOPT might still exit with ``82``, ``83``, or ``84``, but this should automate the storage allocation for most cases.
     User-specified values are not overwritten.
-    
 
 Save major iteration variables:
   desc: >

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -92,6 +92,7 @@ class SNOPT(Optimizer):
             "iSumm": [int, 19],
             "Print file": [str, "SNOPT_print.out"],
             "Summary file": [str, "SNOPT_summary.out"],
+            "Minor print level": [int, 0],
             "Problem Type": [str, ["Minimize", "Maximize", "Feasible point"]],
             "Start": [str, ["Cold", "Warm"]],
             "Derivative level": [int, 3],


### PR DESCRIPTION
## Purpose
I changed the default SNOPT options to suppress the minor print log

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Try it locally, the minor printing log no longer appears.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
