### PR TITLE
Fixed hot start gradient bug

### DIFF
--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -347,7 +347,9 @@ class Optimizer(BaseSolver):
         returns = []
         # Start with fobj:
         if "fobj" in evaluate:
-            if not np.isclose(x, self.cache["x"], atol=EPS, rtol=EPS).all():
+            if not np.isclose(x, self.cache["x"], atol=EPS, rtol=EPS).all() or "funcs" not in self.cache:
+                # The previous evaluated point is different than the point requested
+                # OR this is the first recursive call to _masterFunc2 in a hot started optimization
                 timeA = time.time()
                 args = self.optProb.objFun(xuser)
                 if isinstance(args, tuple):
@@ -392,7 +394,9 @@ class Optimizer(BaseSolver):
             hist["funcs"] = self.cache["funcs"]
 
         if "fcon" in evaluate:
-            if not np.isclose(x, self.cache["x"], atol=EPS, rtol=EPS).all():
+            if not np.isclose(x, self.cache["x"], atol=EPS, rtol=EPS).all() or "funcs" not in self.cache:
+                # The previous evaluated point is different than the point requested
+                # OR this is the first recursive call to _masterFunc2 in a hot started optimization
                 timeA = time.time()
 
                 args = self.optProb.objFun(xuser)
@@ -438,10 +442,10 @@ class Optimizer(BaseSolver):
             hist["funcs"] = self.cache["funcs"]
 
         if "gobj" in evaluate:
-            if not np.isclose(x, self.cache["x"], atol=EPS, rtol=EPS).all():
-                # Previous evaluated point is *different* than the
-                # point requested for the derivative. Recursively call
-                # the routine with ['fobj', and 'fcon']
+            if not np.isclose(x, self.cache["x"], atol=EPS, rtol=EPS).all() or "funcs" not in self.cache:
+                # The previous evaluated point is different than the point requested for the derivative
+                # OR this is the first call to _masterFunc2 in a hot started optimization
+                # Recursively call the routine with ['fobj', 'fcon']
                 self._masterFunc2(x, ["fobj", "fcon"], writeHist=False)
                 # We *don't* count that extra call, since that will
                 # screw up the numbering...so we subtract the last call.
@@ -493,10 +497,10 @@ class Optimizer(BaseSolver):
                 hist["funcsSens"] = self.cache["funcsSens"]
 
         if "gcon" in evaluate:
-            if not np.isclose(x, self.cache["x"], atol=EPS, rtol=EPS).all():
-                # Previous evaluated point is *different* than the
-                # point requested for the derivative. Recursively call
-                # the routine with ['fobj', and 'fcon']
+            if not np.isclose(x, self.cache["x"], atol=EPS, rtol=EPS).all() or "funcs" not in self.cache:
+                # The previous evaluated point is different than the point requested for the derivative
+                # OR this is the first call to _masterFunc2 in a hot started optimization
+                # Recursively call the routine with ['fobj', 'fcon']
                 self._masterFunc2(x, ["fobj", "fcon"], writeHist=False)
                 # We *don't* count that extra call, since that will
                 # screw up the numbering...so we subtract the last call.

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -349,7 +349,8 @@ class Optimizer(BaseSolver):
         if "fobj" in evaluate:
             if not np.isclose(x, self.cache["x"], atol=EPS, rtol=EPS).all() or "funcs" not in self.cache:
                 # The previous evaluated point is different than the point requested
-                # OR this is the first recursive call to _masterFunc2 in a hot started optimization
+                # OR this is a recursive call to _masterFunc2 from a gradient evaluation that occured
+                # at the beginning of a hot started optimization
                 timeA = time.time()
                 args = self.optProb.objFun(xuser)
                 if isinstance(args, tuple):
@@ -396,7 +397,8 @@ class Optimizer(BaseSolver):
         if "fcon" in evaluate:
             if not np.isclose(x, self.cache["x"], atol=EPS, rtol=EPS).all() or "funcs" not in self.cache:
                 # The previous evaluated point is different than the point requested
-                # OR this is the first recursive call to _masterFunc2 in a hot started optimization
+                # OR this is a recursive call to _masterFunc2 from a gradient evaluation that occured
+                # at the beginning of a hot started optimization
                 timeA = time.time()
 
                 args = self.optProb.objFun(xuser)

--- a/tests/test_rosenbrock.py
+++ b/tests/test_rosenbrock.py
@@ -6,6 +6,7 @@ import unittest
 # External modules
 import numpy as np
 from parameterized import parameterized
+from sqlitedict import SqliteDict
 
 # First party modules
 from pyoptsparse import History, Optimization
@@ -117,6 +118,35 @@ class TestRosenbrock(OptTest):
         self.assertEqual(data["feasibility"].shape, (1, 1))
         self.assertEqual(data["slack"].shape, (1, 1))
         self.assertEqual(data["lambda"].shape, (1, 1))
+
+    def test_snopt_hotstart_starting_from_grad(self):
+        self.optName = "SNOPT"
+        self.setup_optProb()
+        histName = f"{self.id()}.hst"
+
+        # Optimize without hot start and store the history
+        self.optimize(storeHistory=histName, hotStart=False)
+
+        # Load the history dictionary
+        hist = SqliteDict(histName)
+
+        # Delete the last two keys in the dictionary
+        lastKey = hist["last"]
+        for i in range(2):
+            del hist[str(int(lastKey) - i)]
+        hist.commit()
+
+        # Optimize starting from the modified history file
+        # The first call will be a gradient evaluation
+        self.optimize(storeHistory=False, hotStart=histName)
+
+        # Check that we had two function evaluations
+        # The first is from a recursive call and the second is the 'last' call we deleted
+        self.assertEqual(self.nf, 2)
+
+        # Also check that we had two gradient evaluations
+        # The first is from a call we deleted and the second is the call after 'last'
+        self.assertEqual(self.ng, 2)
 
     @parameterized.expand(["IPOPT", "SLSQP", "PSQP", "CONMIN", "NLPQLP", "ParOpt"])
     def test_optimization(self, optName):


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->

If an optimization crashes in the middle of a gradient call, attempting to hot start the optimization will give the following error:

```
.../pyoptsparse/pyOpt_optimizer.py", line 454, in _masterFunc2
    args = self.sens(xuser, self.cache["funcs"])
KeyError: 'funcs'
```

I fixed this by re-evaluating the functions if the `funcs` key does not exist.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
Regular urgency; one week

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
I tried to create a test, but this bug proved difficult to reproduce even with manual modification of the history file.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
