### PR TITLE
Updated default pySNOPT options

### DIFF
--- a/doc/optimizers/SNOPT_options.yaml
+++ b/doc/optimizers/SNOPT_options.yaml
@@ -30,6 +30,16 @@ Derivative level:
   desc: >
     The SNOPT derivative level. Only "3" is tested, where all derivatives are provided to SNOPT.
 
+Iterations limit:
+  desc: >
+    The limit on the total number of minor iterations, summed over all major iterations.
+    This option is set to a very large number to prevent premature termination of SNOPT.
+
+Minor iterations limit:
+  desc: >
+    The limit on the number of minor iterations *for each major iteration*.
+    This option is set to a very large number to prevent premature termination of SNOPT.
+
 Proximal iterations limit:
   desc: >
     The iterations limit for solving the proximal point problem.

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -102,6 +102,8 @@ class SNOPT(Optimizer):
             "Problem Type": [str, ["Minimize", "Maximize", "Feasible point"]],
             "Start": [str, ["Cold", "Hot"]],
             "Derivative level": [int, 3],
+            "Iterations limit": [int, 10000000],
+            "Minor iterations limit": [int, 10000],
             "Proximal iterations limit": [int, 10000],
             "Total character workspace": [int, None],
             "Total integer workspace": [int, None],


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
Closes #288. I chose not to set Hessian memory stuff since I think it's a bit confusing, and I didn't set the superbasics limit since I think that's a bit problem dependent. In any case, I'm happy to continue the discussion here if anyone feels strongly about adding any other default options here.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
As long as it takes for us to converge to a reasonable set of options.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
None, existing tests should cover it.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
