### PR TITLE
Enable user requested termination if IPOPT

### DIFF
--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -183,9 +183,7 @@ class IPOPT(Optimizer):
 
         if self.optProb.nCon > 0:
             # We need to reorder this full Jacobian...so get ordering:
-            indices, blc, buc, fact = self.optProb.getOrdering(
-                ["ne", "ni", "le", "li"], oneSided=False
-            )
+            indices, blc, buc, fact = self.optProb.getOrdering(["ne", "ni", "le", "li"], oneSided=False)
             self.optProb.jacIndices = indices
             self.optProb.fact = fact
             self.optProb.offset = np.zeros(len(indices))
@@ -274,9 +272,7 @@ class IPOPT(Optimizer):
             optTime = time.time() - timeA
 
             if self.storeHistory:
-                self.metadata["endTime"] = datetime.datetime.now().strftime(
-                    "%Y-%m-%d %H:%M:%S"
-                )
+                self.metadata["endTime"] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                 self.metadata["optTime"] = optTime
                 self.hist.writeData("metadata", self.metadata)
                 self.hist.close()

--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -90,7 +90,14 @@ class IPOPT(Optimizer):
         return defOpts
 
     def __call__(
-        self, optProb, sens=None, sensStep=None, sensMode=None, storeHistory=None, hotStart=None, storeSens=True
+        self,
+        optProb,
+        sens=None,
+        sensStep=None,
+        sensMode=None,
+        storeHistory=None,
+        hotStart=None,
+        storeSens=True,
     ):
         """
         This is the main routine used to solve the optimization
@@ -176,7 +183,9 @@ class IPOPT(Optimizer):
 
         if self.optProb.nCon > 0:
             # We need to reorder this full Jacobian...so get ordering:
-            indices, blc, buc, fact = self.optProb.getOrdering(["ne", "ni", "le", "li"], oneSided=False)
+            indices, blc, buc, fact = self.optProb.getOrdering(
+                ["ne", "ni", "le", "li"], oneSided=False
+            )
             self.optProb.jacIndices = indices
             self.optProb.fact = fact
             self.optProb.offset = np.zeros(len(indices))
@@ -197,7 +206,10 @@ class IPOPT(Optimizer):
 
             # Now what we need for IPOPT is precisely the .row and
             # .col attributes of the fullJacobian array
-            matStruct = (jac["coo"][IROW].copy().astype("int_"), jac["coo"][ICOL].copy().astype("int_"))
+            matStruct = (
+                jac["coo"][IROW].copy().astype("int_"),
+                jac["coo"][ICOL].copy().astype("int_"),
+            )
 
             # Define the 4 call back functions that ipopt needs:
             def eval_f(x, user_data=None):
@@ -240,7 +252,18 @@ class IPOPT(Optimizer):
             nnzh = 0
 
             nlp = pyipoptcore.create(
-                len(xs), blx, bux, ncon, blc, buc, nnzj, nnzh, eval_f, eval_grad_f, eval_g, eval_jac_g
+                len(xs),
+                blx,
+                bux,
+                ncon,
+                blc,
+                buc,
+                nnzj,
+                nnzh,
+                eval_f,
+                eval_grad_f,
+                eval_g,
+                eval_jac_g,
             )
 
             nlp.set_intermediate_callback(eval_intermediate_callback)
@@ -251,7 +274,9 @@ class IPOPT(Optimizer):
             optTime = time.time() - timeA
 
             if self.storeHistory:
-                self.metadata["endTime"] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                self.metadata["endTime"] = datetime.datetime.now().strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                )
                 self.metadata["optTime"] = optTime
                 self.hist.writeData("metadata", self.metadata)
                 self.hist.close()

--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -144,6 +144,8 @@ class IPOPT(Optimizer):
         self.callCounter = 0
         self.storeSens = storeSens
 
+        self.userRequestedTermination = False
+
         if len(optProb.constraints) == 0:
             # If the user *actually* has an unconstrained problem,
             # snopt sort of chokes with that....it has to have at
@@ -200,14 +202,20 @@ class IPOPT(Optimizer):
             # Define the 4 call back functions that ipopt needs:
             def eval_f(x, user_data=None):
                 fobj, fail = self._masterFunc(x, ["fobj"])
+                if fail == 2:
+                    self.userRequestedTermination = True
                 return fobj
 
             def eval_g(x, user_data=None):
                 fcon, fail = self._masterFunc(x, ["fcon"])
+                if fail == 2:
+                    self.userRequestedTermination = True
                 return fcon.copy()
 
             def eval_grad_f(x, user_data=None):
                 gobj, fail = self._masterFunc(x, ["gobj"])
+                if fail == 2:
+                    self.userRequestedTermination = True
                 return gobj.copy()
 
             def eval_jac_g(x, flag, user_data=None):
@@ -215,7 +223,17 @@ class IPOPT(Optimizer):
                     return copy.deepcopy(matStruct)
                 else:
                     gcon, fail = self._masterFunc(x, ["gcon"])
+                    if fail == 2:
+                        self.userRequestedTermination = True
                     return gcon.copy()
+
+            # Define intermediate callback
+            # If this method returns false, Ipopt will terminate with the User_Requested_Stop status.
+            def eval_intermediate_callback(*args, **kwargs):
+                if self.userRequestedTermination is True:
+                    return False
+                else:
+                    return True
 
             timeA = time.time()
             nnzj = len(matStruct[0])
@@ -224,6 +242,8 @@ class IPOPT(Optimizer):
             nlp = pyipoptcore.create(
                 len(xs), blx, bux, ncon, blc, buc, nnzj, nnzh, eval_f, eval_grad_f, eval_g, eval_jac_g
             )
+
+            nlp.set_intermediate_callback(eval_intermediate_callback)
 
             self._set_ipopt_options(nlp)
             x, zl, zu, constraint_multipliers, obj, status = nlp.solve(xs)

--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -239,8 +239,8 @@ class IPOPT(Optimizer):
                         self.userRequestedTermination = True
                     return gcon.copy()
 
-            # Define intermediate callback
-            # If this method returns false, Ipopt will terminate with the User_Requested_Stop status.
+            # Define intermediate callback. If this method returns false,
+            # Ipopt will terminate with the User_Requested_Stop status.
             def eval_intermediate_callback(*args, **kwargs):
                 if self.userRequestedTermination is True:
                     return False

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ def run_meson_build():
     with open(setup_log, "wb") as f:
         f.write(p1.stdout)
     if p1.returncode != 0:
+        with open(setup_log, "r") as f:
+            print(f.read())
         raise OSError(sysargs, f"The meson setup command failed! Check the log at {setup_log} for more information.")
 
     # build
@@ -45,6 +47,8 @@ def run_meson_build():
     with open(compile_log, "wb") as f:
         f.write(p2.stdout)
     if p2.returncode != 0:
+        with open(compile_log, "r") as f:
+            print(f.read())
         raise OSError(
             sysargs, f"The meson compile command failed! Check the log at {compile_log} for more information."
         )

--- a/tests/test_user_termination.py
+++ b/tests/test_user_termination.py
@@ -73,8 +73,7 @@ def setup_optProb(termcomp):
 
     con_jac = {"x": np.array(-1.0), "y": np.array(1.0)}
 
-    optProb.addConGroup("con", 1, lower=-15.0, upper=-15.0, wrt=["x", "y"],
-                        linear=True, jac=con_jac)
+    optProb.addConGroup("con", 1, lower=-15.0, upper=-15.0, wrt=["x", "y"], linear=True, jac=con_jac)
 
     return optProb
 

--- a/tests/test_user_termination.py
+++ b/tests/test_user_termination.py
@@ -13,7 +13,7 @@ import numpy as np
 from parameterized import parameterized
 
 # First party modules
-from pyoptsparse import Optimization, OPT
+from pyoptsparse import OPT, Optimization
 from pyoptsparse.pyOpt_error import Error
 
 
@@ -73,9 +73,8 @@ def setup_optProb(termcomp):
 
     con_jac = {"x": np.array(-1.0), "y": np.array(1.0)}
 
-    optProb.addConGroup(
-        "con", 1, lower=-15.0, upper=-15.0, wrt=["x", "y"], linear=True, jac=con_jac
-    )
+    optProb.addConGroup("con", 1, lower=-15.0, upper=-15.0, wrt=["x", "y"],
+                        linear=True, jac=con_jac)
 
     return optProb
 


### PR DESCRIPTION
## Purpose

The intent of this change is to enable the IPOPT Optimizer to respond to a user requested termination in the same way that the SNOPT Optimizer does.

As with SNOPT, a value of 2 returned in the `fail` flag from a user evaluation function will be interpreted as a request to terminate the optimization.  This is accomplished by means of the `intermediate_callback` in the IPOPT API.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
Not urgent.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
The existing `user_termination` test for SNOPT has been updated to test IPOPT as well.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [X] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
  - I ran `black` and `flake8` but left a few existing lines that `flake8` complained were over 80 columns
  - my `black` made some changes that your `black` didn't like
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [X] I have run unit and regression tests which pass locally with my changes
- [X] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
