### PR TITLE
Hard code meson version for Windows build so that tests pass

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -4,7 +4,7 @@ dependencies:
   - numpy >=1.16
   - ipopt
   - swig
-  - meson >=0.60
+  - meson =0.61
   - compilers
   - pkg-config
   - pip


### PR DESCRIPTION
#305 exposed an issue with using the latest Meson to build Windows. Turns out, the conda-forge feedstock already hardcoded the Meson version to 0.61 which would explain why there haven't been issues with the conda-forge build.

To get the tests to pass, I hard coded the Meson version in the `.github/environment.yaml` file to 0.61. Apparently, an issue has been opened in the Meson repo [here](https://github.com/mesonbuild/meson/issues/10778) discussing the issue. Until this is fixed, it seems 0.61 is the way to go.