### PR TITLE
Updated IPOPT build instructions for other linear solvers

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -6,5 +6,5 @@ import_heading_stdlib=Standard Python modules
 import_heading_thirdparty=External modules
 import_heading_firstparty=First party modules
 import_heading_localfolder=Local modules
-skip_glob=**__init__.py,**setup.py
+skip_glob=**__init__.py,setup.py
 known_local_folder=testing_utils

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -27,7 +27,7 @@ pyOptSparse has the following dependencies:
 Please make sure these are installed and available for use.
 In order to use NSGA2, SWIG (v1.3+) is also required, which can be installed via the package manager.
 If those optimizers are not needed, then you do not need to install SWIG.
-Simply comment out the corresponding lines in ``pyoptsparse/pyoptsparse/setup.py`` so that they are not compiled.
+Simply comment out the corresponding lines in ``pyoptsparse/pyoptsparse/meson.build`` so that they are not compiled.
 The corresponding lines in ``pyoptsparse/pyoptsparse/__init__.py`` must be commented out as well.
 
 Python dependencies are automatically handled by ``pip``, so they do not need to be installed separately.

--- a/doc/optimizers/IPOPT.rst
+++ b/doc/optimizers/IPOPT.rst
@@ -68,16 +68,6 @@ Here we explain a basic setup using MUMPS as the linear solver, together with ME
 
 #. Now clean build pyOptSparse. Verify that IPOPT works by running the relevant tests.
 
-.. note::
-
-   To get IPOPT working with pyOptSparse when using another linear solver, several things must be changed.
-
-   #. The ``setup.py`` file located in ``pyoptsparse/pyIPOPT`` must be updated accordingly.
-      In particular, the ``libraries=`` line must be changed to reflect the alternate linear solver.
-      For  example, for HSL you need to replace ``coinmumps`` and ``coinmetis`` with ``coinhsl``.
-   #. The option ``linear_solver`` in the options dictionary must be changed.
-      The default value can be changed in ``pyIPOPT.py`` so that this option does not need to be manually set in every run script.
-
 Options
 -------
 Please refer to the `IPOPT website <https://coin-or.github.io/Ipopt/OPTIONS.html>`__ for complete listing of options.


### PR DESCRIPTION
## Purpose
The current docs have a note about building IPOPT for pyOptSparse with linear solvers other than mumps. Now that meson is used, this is outdated.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
