### PR TITLE
Update informs list to be consistent with SNOPT 7.7 + updating docstrings for flake8 rst checks

### DIFF
--- a/doc/advancedFeatures.rst
+++ b/doc/advancedFeatures.rst
@@ -62,6 +62,12 @@ Because the hot start process will store all the previous "restarted" iterations
 
 Time limit (for SNOPT only)
 ---------------------------
+
+.. note::
+
+   Since SNOPT 7.7, the user should rely on the ``Time Limit`` SNOPT option instead of the ``timeLimit`` argument of the ``Optimizer`` instance to set the maximum optimization time.
+
+
 The :ref:`optimizer` class in pyOptSparse has an attribute used to set the maximum allowable wall time for optimizations using SNOPT.
 The code will exit gracefully when such time limit is reached.
 This feature is particularly useful when running a time-constrained job, as in the case of most HPC systems.
@@ -78,6 +84,7 @@ Note that the attribute takes the maximum wall time *in seconds* as an integer n
    pyOptSparse will verify that the computational time is not exceeded before proceeding to the next iteration.
    It will NOT interrupt an ongoing function or sensitivity evaluation.
    If your function evaluations are expensive, you should be more conservative when setting the ``timeLimit`` option for it to be effective.
+
 
 .. Clean Optimization Termination
 .. ------------------------------

--- a/examples/tp109.py
+++ b/examples/tp109.py
@@ -2,6 +2,7 @@
 Solves Schittkowski's TP109 constraint problem.
 
     min 	3.0*x1+1.*10**(-6)*x1**3+0.522074*10**(-6)*x2**3+2.0*x2
+
     s.t.    -(x4-x3+0.550) <= 0
             -(x3-x4+0.550) <= 0
             -(2.25*10**(+6)-x1**2-x8**2) <= 0
@@ -16,6 +17,7 @@ Solves Schittkowski's TP109 constraint problem.
             -0.55 <= xi <= 0.55, i = 3,4
             196.0 <= xi <= 252.0, i = 5,6,7
             -400.0 <= xi <= 800.0, i = 8,9
+
     where   a = 50.176
             b = np.sin(0.25)
             c = np.cos(0.25)

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -1197,7 +1197,8 @@ class Optimization:
     def processContoVec(
         self, fcon_in: Dict1DType, scaled: bool = True, dtype: str = "d", natural: bool = False
     ) -> ndarray:
-        """
+        """A function that converts a dictionary of constraints into a vector
+
         Parameters
         ----------
         fcon_in : dict
@@ -1267,7 +1268,8 @@ class Optimization:
     def processContoDict(
         self, fcon_in: ndarray, scaled: bool = True, dtype: str = "d", natural: bool = False, multipliers: bool = False
     ) -> Dict1DType:
-        """
+        """A function that converts an array of constraints into a dictionary
+
         Parameters
         ----------
         fcon_in : array

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -941,7 +941,7 @@ def OPT(optName, *args, **kwargs):
        Either a string identifying the optimizer to create, e.g. "SNOPT", or
        an enum accessed via ``pyoptsparse.Optimizers``, e.g. ``Optimizers.SNOPT``.
 
-    *args, **kwargs : varies
+    \*args, \*\*kwargs : varies
        Passed to optimizer creation.
 
     Returns

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -116,18 +116,21 @@ class SNOPT(Optimizer):
 
     @staticmethod
     def _getInforms() -> Dict[int, str]:
+        # INFO exit codes for SNOPT 7.7
         informs = {
             0: "finished successfully",
             1: "optimality conditions satisfied",
             2: "feasible point found",
             3: "requested accuracy could not be achieved",
-            4: "weak QP minimizer",
+            5: "elastic objective minimized",
+            6: "elastic infeasibilities minimized",
             10: "the problem appears to be infeasible",
             11: "infeasible linear constraints",
             12: "infeasible linear equalities",
             13: "nonlinear infeasibilities minimized",
             14: "infeasibilities minimized",
             15: "infeasible linear constraints in QP subproblem",
+            16: "infeasible nonelastic constraints",
             20: "the problem appears to be unbounded",
             21: "unbounded objective",
             22: "constraint violation limit reached",
@@ -135,17 +138,16 @@ class SNOPT(Optimizer):
             31: "iteration limit reached",
             32: "major iteration limit reached",
             33: "the superbasics limit is too small",
+            34: "time limit reached",
             40: "terminated after numerical difficulties",
             41: "current point cannot be improved",
             42: "singular basis",
             43: "cannot satisfy the general constraints",
             44: "ill-conditioned null-space basis",
+            45: "unable to compute acceptable LU factors",
             50: "error in the user-supplied functions",
             51: "incorrect objective  derivatives",
             52: "incorrect constraint derivatives",
-            53: "the QP Hessian is indefinite",
-            54: "incorrect second derivatives",
-            55: "incorrect derivatives",
             56: "irregular or badly scaled problem functions",
             60: "undefined user-supplied functions",
             61: "undefined function at the first feasible point",
@@ -153,8 +155,6 @@ class SNOPT(Optimizer):
             63: "unable to proceed into undefined region",
             70: "user requested termination",
             71: "terminated during function evaluation",
-            72: "terminated during constraint evaluation",
-            73: "terminated during objective evaluation",
             74: "terminated from monitor routine",
             80: "insufficient storage allocated",
             81: "work arrays must have at least 500 elements",
@@ -164,6 +164,19 @@ class SNOPT(Optimizer):
             90: "input arguments out of range",
             91: "invalid input argument",
             92: "basis file dimensions do not match this problem",
+            140: "system error",
+            141: "wrong no of basic variables",
+            142: "error in basis package",
+        }
+
+        # INFO exit codes from SNOPT 7.2
+        informs_old = {
+            4: "weak QP minimizer",
+            53: "the QP Hessian is indefinite",
+            54: "incorrect second derivatives",
+            55: "incorrect derivatives",
+            72: "terminated during constraint evaluation",
+            73: "terminated during objective evaluation",
             93: "the QP Hessian is indefinite",
             100: "finished successfully",
             101: "SPECS file read",
@@ -184,10 +197,10 @@ class SNOPT(Optimizer):
             132: "End-of-file while looking for a BEGIN",
             133: "End-of-file while reading SPECS file",
             134: "ENDRUN found before any valid SPECS",
-            140: "system error",
-            141: "wrong no of basic variables",
-            142: "error in basis package",
         }
+
+        informs.update(informs_old)
+
         return informs
 
     def __call__(

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -169,38 +169,6 @@ class SNOPT(Optimizer):
             142: "error in basis package",
         }
 
-        # INFO exit codes from SNOPT 7.2
-        informs_old = {
-            4: "weak QP minimizer",
-            53: "the QP Hessian is indefinite",
-            54: "incorrect second derivatives",
-            55: "incorrect derivatives",
-            72: "terminated during constraint evaluation",
-            73: "terminated during objective evaluation",
-            93: "the QP Hessian is indefinite",
-            100: "finished successfully",
-            101: "SPECS file read",
-            102: "Jacobian structure estimated",
-            103: "MPS file read",
-            104: "memory requirements estimated",
-            105: "user-supplied derivatives appear to be correct",
-            106: "no derivatives were checked",
-            107: "some SPECS keywords were not recognized",
-            110: "errors while processing MPS data",
-            111: "no MPS file specified",
-            112: "problem-size estimates too small",
-            113: "fatal error in the MPS file",
-            120: "errors while estimating Jacobian structure",
-            121: "cannot find Jacobian structure at given point",
-            130: "fatal errors while reading the SP",
-            131: "no SPECS file (iSpecs le 0 or iSpecs gt 99)",
-            132: "End-of-file while looking for a BEGIN",
-            133: "End-of-file while reading SPECS file",
-            134: "ENDRUN found before any valid SPECS",
-        }
-
-        informs.update(informs_old)
-
         return informs
 
     def __call__(

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -269,7 +269,7 @@ class SNOPT(Optimizer):
             Specify the maximum amount of time for optimizer to run.
             Must be in seconds. This can be useful on queue systems when
             you want an optimization to cleanly finish before the
-            job runs out of time.
+            job runs out of time. From SNOPT 7.7, use the "Time limit" option instead.
 
         restartDict : dict
             A dictionary containing the necessary information for hot-starting SNOPT.

--- a/tests/test_hs071.py
+++ b/tests/test_hs071.py
@@ -173,6 +173,8 @@ class TestHS71(OptTest):
         self.setup_optProb()
         sol = self.optimize(optOptions={"Major iterations limit": 1})
         self.assert_inform_equal(sol, 32)
+        sol = self.optimize(optOptions={"Time Limit": 0.001})
+        self.assert_inform_equal(sol, 34)
 
     def test_slsqp_informs(self):
         self.optName = "SLSQP"

--- a/tests/test_tp109.py
+++ b/tests/test_tp109.py
@@ -2,6 +2,7 @@
 Test uses Schittkowski's TP109 constraint problem.
 
     min 	3.0*x1+1.*10**(-6)*x1**3+0.522074*10**(-6)*x2**3+2.0*x2
+
     s.t.    -(x4-x3+0.550) <= 0
             -(x3-x4+0.550) <= 0
             -(2.25*10**(+6)-x1**2-x8**2) <= 0
@@ -16,6 +17,7 @@ Test uses Schittkowski's TP109 constraint problem.
             -0.55 <= xi <= 0.55, i = 3,4
             196.0 <= xi <= 252.0, i = 5,6,7
             -400.0 <= xi <= 800.0, i = 8,9
+
     where   a = 50.176
             b = np.sin(0.25)
             c = np.cos(0.25)


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
I updated the `informs` dictionary to include all the supported `INFO` exit codes in SNOPT 7.7 (see list on the [manual](http://www.sbsi-sol-optimize.com/manuals/SNOPT%20Manual.pdf), page 42).
A few of the current codes are not used in v7.7 anymore, so I removed them from the list. This will not affect backward compatibility as we don't support versions <7.7.

Closes #332 

P.S. I edited a few docstrings that were creating issues with the new flake8 rst checks, since this is the first PR affected by the new check for this repo

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
1-2 days

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
