### PR TITLE
fix deprecation in alpso

### DIFF
--- a/pyoptsparse/pyALPSO/alpso.py
+++ b/pyoptsparse/pyALPSO/alpso.py
@@ -55,7 +55,7 @@ def alpso(dimensions, constraints, neqcons, xtype, x0, xmin, xmax, swarmsize, nh
     """
 
     #
-    if x0 != []:
+    if x0.size > 0:
         if isinstance(x0, list):
             x0 = np.array(x0)
         elif not isinstance(x0, np.ndarray):
@@ -110,7 +110,7 @@ def alpso(dimensions, constraints, neqcons, xtype, x0, xmin, xmax, swarmsize, nh
     else:
         diI = 0
 
-    if x0 != []:
+    if x0.size > 0:
         if len(x0.shape) == 1:
             nxi = 1
         else:
@@ -175,7 +175,7 @@ def alpso(dimensions, constraints, neqcons, xtype, x0, xmin, xmax, swarmsize, nh
 
             v_k[i, j] = (xmin[j] + rand.random() * (xmax[j] - xmin[j])) / dt
 
-    if x0 != []:
+    if x0.size > 0:
         if len(x0.shape) == 1:
             if scale == 1:
                 x_k[0, :] = (x0[:] - space_centre) / space_halflen

--- a/pyoptsparse/pyALPSO/alpso_ext.py
+++ b/pyoptsparse/pyALPSO/alpso_ext.py
@@ -55,7 +55,7 @@ def alpso(dimensions, constraints, neqcons, xtype, x0, xmin, xmax, swarmsize, nh
     """
 
     #
-    if x0 != []:
+    if x0.size > 0:
         if isinstance(x0, list):
             x0 = np.array(x0)
         elif not isinstance(x0, np.ndarray):
@@ -110,7 +110,7 @@ def alpso(dimensions, constraints, neqcons, xtype, x0, xmin, xmax, swarmsize, nh
     else:
         diI = 0
 
-    if x0 != []:
+    if x0.size > 0:
         if len(x0.shape) == 1:
             nxi = 1
         else:
@@ -175,7 +175,7 @@ def alpso(dimensions, constraints, neqcons, xtype, x0, xmin, xmax, swarmsize, nh
 
             v_k[i, j] = (xmin[j] + rand.random() * (xmax[j] - xmin[j])) / dt
 
-    if x0 != []:
+    if x0.size > 0:
         if len(x0.shape) == 1:
             if scale == 1:
                 x_k[0, :] = (x0[:] - space_centre) / space_halflen


### PR DESCRIPTION
## Purpose

This is a simple fix for several occurrences of a deprecation in `alpso.py`:

```
swryan@Chimaera:~/dev/pyoptsparse/tests$ python test_sphere.py
/home/swryan/miniconda3/envs/dymos/lib/python3.11/site-packages/pyoptsparse/pyALPSO/alpso.py:58: DeprecationWarning: elementwise comparison failed; this will raise an error in the future.
  if x0 != []:
/home/swryan/miniconda3/envs/dymos/lib/python3.11/site-packages/pyoptsparse/pyALPSO/alpso.py:113: DeprecationWarning: elementwise comparison failed; this will raise an error in the future.
  if x0 != []:
/home/swryan/miniconda3/envs/dymos/lib/python3.11/site-packages/pyoptsparse/pyALPSO/alpso.py:178: DeprecationWarning: elementwise comparison failed; this will raise an error in the future.
  if x0 != []:
```

Information about the deprecation is here:  https://github.com/numpy/numpy/issues/9583.

The suggested fix is:
```
The truth value of an empty array is ambiguous. Returning False, but in future this will result in an error. Use `array.size > 0` to check that an array is not empty.
```

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing

`python test_sphere.py` should no longer issue the above warning.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
