### PR TITLE
Loosen tolerance on tests to support Mac ARM

### DIFF
--- a/tests/test_hs015.py
+++ b/tests/test_hs015.py
@@ -42,7 +42,7 @@ class TestHS15(OptTest):
         {"xvars": (-0.79212322, -1.26242985)},
     ]
     tol = {
-        "SLSQP": 1e-8,
+        "SLSQP": 1e-5,
         "NLPQLP": 1e-12,
         "IPOPT": 1e-4,
         "ParOpt": 1e-6,


### PR DESCRIPTION
## Purpose
This PR reduces the tolerance on one failing test (hs015, SLSQP) to allow the ARM based Mac Mini to pass (see https://github.com/mdolab/docker/pull/170#issuecomment-1511253227 for more details).

## Expected time until merged
No rush, but needed for https://github.com/mdolab/docker/pull/170

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
Run tests. Users with M1 or M2 CPUs should test this without and with the patch.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
