### PR TITLE
Remove some warnings

### DIFF
--- a/pyoptsparse/__init__.py
+++ b/pyoptsparse/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.9.4"
+__version__ = "2.10.0"
 
 from .pyOpt_history import History
 from .pyOpt_variable import Variable

--- a/pyoptsparse/pyOpt_MPI.py
+++ b/pyoptsparse/pyOpt_MPI.py
@@ -59,11 +59,4 @@ else:
     try:
         from mpi4py import MPI
     except ImportError:
-        warn = (
-            "mpi4py could not be imported. mpi4py is required to use "
-            + "the parallel gradient analysis and parallel objective analysis for "
-            + "non-gradient based optimizers. Continuing using a dummy MPI module "
-            + "from pyOptSparse."
-        )
-        warnings.warn(warn, stacklevel=2)
         MPI = myMPI()

--- a/pyoptsparse/pyOpt_MPI.py
+++ b/pyoptsparse/pyOpt_MPI.py
@@ -8,9 +8,6 @@ pyOptSparse are included here.
 
 # Standard Python modules
 import os
-import warnings
-
-# isort: off
 
 
 class COMM:

--- a/pyoptsparse/pyOpt_MPI.py
+++ b/pyoptsparse/pyOpt_MPI.py
@@ -47,6 +47,7 @@ class myMPI:
 # and raise exception on failure. If set to anything else, no import is attempted.
 if "PYOPTSPARSE_REQUIRE_MPI" in os.environ:
     if os.environ["PYOPTSPARSE_REQUIRE_MPI"].lower() in ["always", "1", "true", "yes"]:
+        # External modules
         from mpi4py import MPI
     else:
         MPI = myMPI()
@@ -54,6 +55,7 @@ if "PYOPTSPARSE_REQUIRE_MPI" in os.environ:
 # with a notification.
 else:
     try:
+        # External modules
         from mpi4py import MPI
     except ImportError:
         MPI = myMPI()

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -4,7 +4,6 @@ import copy
 import os
 import pickle
 from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
-import warnings
 
 # External modules
 import numpy as np

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -227,11 +227,6 @@ class Optimization:
                 f"The 'nVars' argument to addVarGroup must be greater than or equal to 1. The bad DV is {name}."
             )
 
-        # we let type overwrite the newer varType option name
-        if "type" in kwargs:
-            varType = kwargs["type"]
-            # but we also throw a deprecation warning
-            warnings.warn("The argument `type=` is deprecated. Use `varType` in the future.", stacklevel=2)
         # Check that the type is ok
         if varType not in ["c", "i", "d"]:
             raise Error("Type must be one of 'c' for continuous, 'i' for integer or 'd' for discrete.")
@@ -816,10 +811,6 @@ class Optimization:
             self._finalizeConstraints()
             self.finalized = True
 
-    def finalizeDesignVariables(self):
-        warnings.warn("finalizeDesignVariables() is deprecated, use _finalizeDesignVariables() instead.", stacklevel=2)
-        self._finalizeDesignVariables()
-
     def _finalizeDesignVariables(self):
         """
         Communicate design variables potentially from different
@@ -843,10 +834,6 @@ class Optimization:
             self.dvOffset[dvGroup] = [dvCounter, dvCounter + n, self.variables[dvGroup][0].scalar]
             dvCounter += n
         self.ndvs = dvCounter
-
-    def finalizeConstraints(self):
-        warnings.warn("finalizeConstraints() is deprecated, use _finalizeConstraints() instead.", stacklevel=2)
-        self._finalizeConstraints()
 
     def _finalizeConstraints(self):
         """


### PR DESCRIPTION
## Purpose
Two types of warnings are removed:
* warning on failing to import `mpi4py`, IMO this is a bit annoying for those that are not using the parallel features
* deprecation warnings for things that were removed 2+ years ago

We may want to make a release after this is merged, and clearly explain in the release notes that these deprecations are now removed.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
Not urgent

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
