### PR TITLE
Remove callables from optProb only when serializing in History file

### DIFF
--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -2,7 +2,6 @@
 from collections import OrderedDict
 import copy
 import os
-import pickle
 from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 # External modules

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -1761,15 +1761,7 @@ class Optimization:
         The un-serializable fields are deleted first.
         """
         d = copy.copy(self.__dict__)
-        keysToRemove = ["comm"]
-        try:
-            pickle.dumps(self.objFun)
-        except Exception:
-            # Use a blanket exception because pickle errors are unreliable
-            # Tests raise RecursionError
-            # mpi4py raises TypeError
-            keysToRemove.append("objFun")
-        for key in keysToRemove:
+        for key in ["comm"]:
             if key in d.keys():
                 del d[key]
         return d

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -592,14 +592,18 @@ class Optimizer(BaseSolver):
             for objKey in self.optProb.objectives.keys():
                 objInfo[objKey] = {"scale": self.optProb.objectives[objKey].scale}
 
-            # There is a special write for the bounds data
+            # There is a special write for additional metadata
             if self.storeHistory:
                 self.hist.writeData("varInfo", varInfo)
                 self.hist.writeData("conInfo", conInfo)
                 self.hist.writeData("objInfo", objInfo)
                 self._setMetadata()
                 self.hist.writeData("metadata", self.metadata)
-                self.hist.writeData("optProb", self.optProb)
+                # we have to get rid of some callables in optProb before serialization
+                optProb = copy.copy(self.optProb)
+                optProb.objFun = None
+                optProb.sens = None
+                self.hist.writeData("optProb", optProb)
 
         # Write history if necessary
         if self.optProb.comm.rank == 0 and writeHist and self.storeHistory:


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
So, let's unpack the story of what's going on.
1. Originally we removed the `objFun` field when serializing optProb since it's a callable
2. When using multiprocessing, it is important to hold onto those references (see #264), so we keep them if possible (see #266)
3. We also added `optProb.sens` in #212, it is also a callable similar to `objFun` but did not receive the same treatment

Now, instead of just doing the same thing as before, I changed the approach of serialization. When we work with the `Optimization` object, we only get rid of the MPI communicator. When we need to serialize it for the History object, we then remove those fields so they are not serialized. This separation of Optimization vs. History is a little bit cleaner IMO.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
No rush. Please test this with lab tools (SNOPT + MACH) to make sure I didn't break anything. The CI will also not run SNOPT tests so please test those locally.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
We do not have any tests that use the `optProb.sens` field, but I can add some if maintainers feel this is necessary.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [x] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
