### PR TITLE
Save more variables by default in SNOPT history file

### DIFF
--- a/doc/optimizers/SNOPT_options.yaml
+++ b/doc/optimizers/SNOPT_options.yaml
@@ -82,6 +82,17 @@ Save major iteration variables:
     - ``maxVi``
     - ``penalty_vector``
 
+    In addition, a set of default parameters are saved to the history file and cannot be changed. These are
+
+    - ``nMajor``
+    - ``nMinor``
+    - ``step``
+    - ``feasibility``
+    - ``optimality``
+    - ``merit``
+    - ``condZHZ``
+    - ``penalty``
+
 Return work arrays:
   desc: >
     This option is unique to the Python wrapper.

--- a/doc/optimizers/SNOPT_options.yaml
+++ b/doc/optimizers/SNOPT_options.yaml
@@ -77,7 +77,6 @@ Save major iteration variables:
     - ``Hessian``
     - ``slack``
     - ``lambda``
-    - ``condZHZ``
     - ``nS``
     - ``BSwap``
     - ``maxVi``

--- a/doc/optimizers/SNOPT_options.yaml
+++ b/doc/optimizers/SNOPT_options.yaml
@@ -71,9 +71,17 @@ Total real workspace:
 
 Save major iteration variables:
   desc: >
-    This option is unique to the Python wrapper, and takes a list of values which can be saved at each iteration to the History file.
-    This specifies the list of major iteration variables to be stored in the history file.
-    ``Hessian``, ``slack``, ``lambda`` and ``condZHZ`` are also supported.
+    This option is unique to the Python wrapper, and takes a list of values which can be saved at each major iteration to the History file.
+    The possible values are
+
+    - ``Hessian``
+    - ``slack``
+    - ``lambda``
+    - ``condZHZ``
+    - ``nS``
+    - ``BSwap``
+    - ``maxVi``
+    - ``penalty_vector``
 
 Return work arrays:
   desc: >

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -666,7 +666,7 @@ class SNOPT(Optimizer):
             elif saveVar == "maxVi":
                 iterDict[saveVar] = maxvi
             else:
-                raise Error(f"Received unkown SNOPT save variable {saveVar}. "
+                raise Error(f"Received unknown SNOPT save variable {saveVar}. "
                             + "Please see 'Save major iteration variables' option in the pyOptSparse documentation "
                             + "under 'SNOPT'.")
         if self.storeHistory:

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -614,7 +614,7 @@ class SNOPT(Optimizer):
         H = np.matmul(Umat.T, Umat)
         return H
 
-    def _getPenaltyParam(self, iw, rw):
+    def _getPenaltyVector(self, iw, rw):
         """
         Retrieves the full penalty parameter vector from the work arrays.
         """
@@ -651,7 +651,7 @@ class SNOPT(Optimizer):
         }
         for saveVar in self.getOption("Save major iteration variables"):
             if saveVar == "penalty_vector":
-                iterDict[saveVar] = self._getPenaltyParam(iw, rw),
+                iterDict[saveVar] = self._getPenaltyVector(iw, rw),
             elif saveVar == "Hessian":
                 H = self._getHessian(iw, rw)
                 iterDict[saveVar] = H
@@ -666,7 +666,7 @@ class SNOPT(Optimizer):
             elif saveVar == "maxVi":
                 iterDict[saveVar] = maxvi
             else:
-                warnings.warn(f"Received unknown SNOPT save variable {saveVar}")
+                warnings.warn(f"Received unknown SNOPT save variable {saveVar}", stacklevel=2)
         if self.storeHistory:
             currX = x[:n]  # only the first n component is x, the rest are the slacks
             if nmajor == 0:

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -137,10 +137,7 @@ class SNOPT(Optimizer):
             "Total character workspace": [int, None],
             "Total integer workspace": [int, None],
             "Total real workspace": [int, None],
-            "Save major iteration variables": [
-                list,
-                ["step", "merit", "feasibility", "optimality", "penalty"],
-            ],
+            "Save major iteration variables": [list, []],
             "Return work arrays": [bool, False],
             "snSTOP function handle": [(type(None), type(lambda: None)), None],
         }
@@ -627,43 +624,49 @@ class SNOPT(Optimizer):
         return xPen
 
     # fmt: off
-    def _snstop(self, ktcond, mjrprtlvl, minimize, n, nncon, nnobj, ns, itn, nmajor, nminor, nswap, condzhz, iobj, scaleobj,
-                objadd, fobj, fmerit, penparm, step, primalinf, dualinf, maxvi, maxvirel, hs, locj, indj, jcol, scales, bl, bu, fx, fcon, gcon, gobj, ycon,
-                pi, rc, rg, x, cu, iu, ru, cw, iw, rw):
+    def _snstop(self, ktcond, mjrprtlvl, minimize, n, nncon, nnobj, ns, itn, nmajor, nminor, nswap, condzhz, iobj,
+                scaleobj, objadd, fobj, fmerit, penparm, step, primalinf, dualinf, maxvi, maxvirel, hs, locj, indj,
+                jcol, scales, bl, bu, fx, fcon, gcon, gobj, ycon, pi, rc, rg, x, cu, iu, ru, cw, iw, rw):
         # fmt: on
         """
         This routine is called every major iteration in SNOPT, after solving QP but before line search
         We use it to determine the correct major iteration counting, and save some parameters in the history file.
-        If 'snSTOP function handle' is set to a function handle, then the callback is performed at the end of this function.
+        If 'snSTOP function handle' is set to a function handle, then it is called at the end of this function.
 
-        returning with iabort != 0 will terminate SNOPT immediately
+        Returns
+        -------
+        iabort : int
+            The return code expected by SNOPT. A non-zero value will terminate SNOPT immediately.
         """
         iterDict = {
             "isMajor": True,
             "nMajor": nmajor,
             "nMinor": nminor,
+            "step": step,
+            "feasibility": primalinf,
+            "optimality": dualinf,
+            "merit": fmerit,
+            "condZHZ": condzhz,
+            "penalty": penparm[2],
         }
         for saveVar in self.getOption("Save major iteration variables"):
-            if saveVar == "merit":
-                iterDict[saveVar] = fmerit
-            elif saveVar == "feasibility":
-                iterDict[saveVar] = primalinf
-            elif saveVar == "optimality":
-                iterDict[saveVar] = dualinf
-            elif saveVar == "penalty":
-                penParam = self._getPenaltyParam(iw, rw)
-                iterDict[saveVar] = penParam
+            if saveVar == "penalty_vector":
+                iterDict[saveVar] = self._getPenaltyParam(iw, rw),
             elif saveVar == "Hessian":
                 H = self._getHessian(iw, rw)
                 iterDict[saveVar] = H
-            elif saveVar == "step":
-                iterDict[saveVar] = step
-            elif saveVar == "condZHZ":
-                iterDict[saveVar] = condzhz
             elif saveVar == "slack":
                 iterDict[saveVar] = x[n:]
             elif saveVar == "lambda":
                 iterDict[saveVar] = pi
+            elif saveVar == "nS":
+                iterDict[saveVar] = ns
+            elif saveVar == "BSwap":
+                iterDict[saveVar] = nswap
+            elif saveVar == "maxVi":
+                iterDict[saveVar] = maxvi
+            else:
+                warnings.warn(f"Received unknown SNOPT save variable {saveVar}")
         if self.storeHistory:
             currX = x[:n]  # only the first n component is x, the rest are the slacks
             if nmajor == 0:

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -666,7 +666,9 @@ class SNOPT(Optimizer):
             elif saveVar == "maxVi":
                 iterDict[saveVar] = maxvi
             else:
-                warnings.warn(f"Received unknown SNOPT save variable {saveVar}", stacklevel=2)
+                raise Error(f"Received unkown SNOPT save variable {saveVar}. "
+                            + "Please see 'Save major iteration variables' option in the pyOptSparse documentation "
+                            + "under 'SNOPT'.")
         if self.storeHistory:
             currX = x[:n]  # only the first n component is x, the rest are the slacks
             if nmajor == 0:

--- a/tests/test_hs015.py
+++ b/tests/test_hs015.py
@@ -98,7 +98,7 @@ class TestHS15(OptTest):
     def test_snopt(self):
         self.optName = "SNOPT"
         self.setup_optProb()
-        store_vars = ["step", "merit", "feasibility", "optimality", "penalty", "Hessian", "condZHZ", "slack", "lambda"]
+        store_vars = ["Hessian", "slack", "lambda", "penalty_vector", "nS", "BSwap", "maxVi"]
         optOptions = {"Save major iteration variables": store_vars}
         self.optimize_with_hotstart(1e-12, optOptions=optOptions)
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1,9 +1,14 @@
 # Standard Python modules
+import os
 import sys
 import unittest
 
+# we have to unset this environment variable because otherwise when we import `_import_snopt_from_path`
+# the snopt module gets automatically imported, thus failing the import test below
+os.environ.pop("PYOPTSPARSE_IMPORT_SNOPT_FROM", None)
+
 # First party modules
-from pyoptsparse.pySNOPT.pySNOPT import _import_snopt_from_path
+from pyoptsparse.pySNOPT.pySNOPT import _import_snopt_from_path  # noqa: E402
 
 
 class TestImportSnoptFromPath(unittest.TestCase):

--- a/tests/test_rosenbrock.py
+++ b/tests/test_rosenbrock.py
@@ -101,10 +101,8 @@ class TestRosenbrock(OptTest):
     def test_snopt(self):
         self.optName = "SNOPT"
         self.setup_optProb()
-        store_vars = ["step", "merit", "feasibility", "optimality", "penalty", "Hessian", "condZHZ", "slack", "lambda"]
-        optOptions = {
-            "Save major iteration variables": store_vars,
-        }
+        store_vars = ["Hessian", "slack", "lambda", "penalty_vector", "nS", "BSwap", "maxVi"]
+        optOptions = {"Save major iteration variables": store_vars}
         self.optimize_with_hotstart(1e-8, optOptions=optOptions)
 
         hist = History(self.histFileName, flag="r")


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
I updated the `snSTOP` function to save more variables by default in the Python layer. The option `Save major iteration variables` now defaults to an empty list. The following variables are saved (the user cannot turn these off)
- `isMajor`
- `nMajor`
- `nMinor`
- `step`
- `feasibility`
- `optimality`
- `merit`
- `condZHZ`
- `penalty`

and the following can be added via the option
- `Hessian`
- `slack`
- `lambda`
- `condZHZ`
- `nS`
- `BSwap`
- `maxVi`
- `penalty_vector`

Happy to discuss names/which ones should be saved by default. I think it's possible to have everything in the major iteration log saved, but the defaults I feel are the ones people actually care about (at least given my limited knowledge of SNOPT).

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
A few days. Maybe we can do a minor release after this and #346 are both merged?

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

I don't believe this is a backwards-breaking change, but happy to discuss. Also please run tests since the CI will not check SNOPT-related stuff.

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
I updated the existing tests. As usual, the CI will not test SNOPT so please test this locally.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
