### PR TITLE
More tolerant scalar check

### DIFF
--- a/pyoptsparse/__init__.py
+++ b/pyoptsparse/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.10.0"
+__version__ = "2.10.1"
 
 from .pyOpt_history import History
 from .pyOpt_variable import Variable

--- a/pyoptsparse/pyOpt_constraint.py
+++ b/pyoptsparse/pyOpt_constraint.py
@@ -8,7 +8,7 @@ import numpy as np
 
 # Local modules
 from .pyOpt_error import Error, pyOptSparseWarning
-from .pyOpt_utils import INFINITY, convertToCOO
+from .pyOpt_utils import INFINITY, convertToCOO, _broadcast_to_array
 from .types import Dict1DType
 
 
@@ -43,41 +43,9 @@ class Constraint:
         # Before we can do the processing below we need to have lower
         # and upper arguments expanded:
 
-        if lower is None:
-            lower = [None for i in range(self.ncon)]
-        elif np.isscalar(lower):
-            lower = lower * np.ones(self.ncon)
-        elif len(lower) == self.ncon:
-            pass  # Some iterable object
-        else:
-            raise Error(
-                "The 'lower' argument to addCon or addConGroup is invalid. "
-                + f"It must be None, a scalar, or a list/array or length nCon={nCon}."
-            )
-
-        if upper is None:
-            upper = [None for i in range(self.ncon)]
-        elif np.isscalar(upper):
-            upper = upper * np.ones(self.ncon)
-        elif len(upper) == self.ncon:
-            pass  # Some iterable object
-        else:
-            raise Error(
-                "The 'upper' argument to addCon or addConGroup is invalid. "
-                + f"It must be None, a scalar, or a list/array or length nCon={nCon}."
-            )
-
-        # ------ Process the scale argument
-        scale = np.atleast_1d(scale)
-        if len(scale) == 1:
-            scale = scale[0] * np.ones(nCon)
-        elif len(scale) == nCon:
-            pass
-        else:
-            raise Error(
-                f"The length of the 'scale' argument to addCon or addConGroup is {len(scale)}, "
-                + f"but the number of constraints is {nCon}."
-            )
+        lower = _broadcast_to_array("lower", lower, nCon)
+        upper = _broadcast_to_array("upper", upper, nCon)
+        scale = _broadcast_to_array("scale", scale, nCon, allow_none=False)
 
         # Save lower and upper...they are only used for printing however
         self.lower = lower

--- a/pyoptsparse/pyOpt_constraint.py
+++ b/pyoptsparse/pyOpt_constraint.py
@@ -8,7 +8,7 @@ import numpy as np
 
 # Local modules
 from .pyOpt_error import Error, pyOptSparseWarning
-from .pyOpt_utils import INFINITY, convertToCOO, _broadcast_to_array
+from .pyOpt_utils import INFINITY, _broadcast_to_array, convertToCOO
 from .types import Dict1DType
 
 

--- a/pyoptsparse/pyOpt_constraint.py
+++ b/pyoptsparse/pyOpt_constraint.py
@@ -43,9 +43,9 @@ class Constraint:
         # Before we can do the processing below we need to have lower
         # and upper arguments expanded:
 
-        lower = _broadcast_to_array("lower", lower, nCon)
-        upper = _broadcast_to_array("upper", upper, nCon)
-        scale = _broadcast_to_array("scale", scale, nCon, allow_none=False)
+        lower = _broadcast_to_array("lower", lower, nCon, allow_none=True)
+        upper = _broadcast_to_array("upper", upper, nCon, allow_none=True)
+        scale = _broadcast_to_array("scale", scale, nCon)
 
         # Save lower and upper...they are only used for printing however
         self.lower = lower

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -20,12 +20,12 @@ from .pyOpt_utils import (
     IDATA,
     INFINITY,
     IROW,
+    _broadcast_to_array,
     convertToCOO,
     convertToCSR,
     mapToCSR,
     scaleColumns,
     scaleRows,
-    _broadcast_to_array,
 )
 from .pyOpt_variable import Variable
 from .types import Dict1DType, Dict2DType, NumpyType

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -243,7 +243,7 @@ class Optimization:
 
         if lower is None:
             lower = [None for i in range(nVars)]
-        elif np.isscalar(lower):
+        elif np.size(lower) == 1:
             lower = lower * np.ones(nVars)
         elif len(lower) == nVars:
             lower = np.atleast_1d(lower).real
@@ -255,7 +255,7 @@ class Optimization:
 
         if upper is None:
             upper = [None for i in range(nVars)]
-        elif np.isscalar(upper):
+        elif np.size(upper) == 1:
             upper = upper * np.ones(nVars)
         elif len(upper) == nVars:
             upper = np.atleast_1d(upper).real

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -240,11 +240,11 @@ class Optimization:
         if varType not in ["c", "i", "d"]:
             raise Error("Type must be one of 'c' for continuous, 'i' for integer or 'd' for discrete.")
 
-        value = _broadcast_to_array("value", value, nVars, allow_none=False)
-        lower = _broadcast_to_array("lower", lower, nVars)
-        upper = _broadcast_to_array("upper", upper, nVars)
-        scale = _broadcast_to_array("scale", scale, nVars, allow_none=False)
-        offset = _broadcast_to_array("offset", offset, nVars, allow_none=False)
+        value = _broadcast_to_array("value", value, nVars)
+        lower = _broadcast_to_array("lower", lower, nVars, allow_none=True)
+        upper = _broadcast_to_array("upper", upper, nVars, allow_none=True)
+        scale = _broadcast_to_array("scale", scale, nVars)
+        offset = _broadcast_to_array("offset", offset, nVars)
 
         # Determine if scalar i.e. it was called from addVar():
         scalar = kwargs.pop("scalar", False)

--- a/pyoptsparse/pyOpt_utils.py
+++ b/pyoptsparse/pyOpt_utils.py
@@ -20,6 +20,7 @@ from scipy.sparse import spmatrix
 
 # Local modules
 from .pyOpt_error import Error
+from .types import ArrayType
 
 # Define index mnemonics
 IROW = 0
@@ -531,11 +532,41 @@ def _csc_to_coo(mat: dict) -> dict:
     return {"coo": [coo_rows, coo_cols, coo_data], "shape": mat["shape"]}
 
 
-def _broadcast_to_array(name: str, value, n_vars: int, allow_none: bool = True):
+def _broadcast_to_array(name: str, value: ArrayType, n_values: int, allow_none: bool = False):
+    """
+    Broadcast an input to an array with a specified length
+
+    Parameters
+    ----------
+    name : str
+        The name of the input. This is only used in the error message emitted.
+    value : float, list[float], numpy array
+        The input value
+    n_values : int
+        The number of values
+    allow_none : bool, optional
+        Whether to allow `None` in the input/output, by default False
+
+    Returns
+    -------
+    NDArray
+        An array with the shape ``(n_values)``
+
+    Raises
+    ------
+    Error
+        If either the input is not broadcastable, or if the input contains None and ``allow_none=False`.
+
+    Warnings
+    --------
+    Note that the default value for ``allow_none`` is False.
+    """
     try:
-        value = np.broadcast_to(value, (n_vars))
+        value = np.broadcast_to(value, n_values)
     except ValueError:
-        raise Error(f"The '{name}' argument is invalid. It must be None, a scalar, or a list/array or length {n_vars}.")
+        raise Error(
+            f"The '{name}' argument is invalid. It must be None, a scalar, or a list/array or length {n_values}."
+        )
     if not allow_none and any([i is None for i in value]):
         raise Error(f"The {name} argument cannot be 'None'.")
     return value

--- a/pyoptsparse/pyOpt_utils.py
+++ b/pyoptsparse/pyOpt_utils.py
@@ -555,7 +555,7 @@ def _broadcast_to_array(name: str, value: ArrayType, n_values: int, allow_none: 
     Raises
     ------
     Error
-        If either the input is not broadcastable, or if the input contains None and ``allow_none=False`.
+        If either the input is not broadcastable, or if the input contains None and ``allow_none=False``.
 
     Warnings
     --------

--- a/pyoptsparse/pyOpt_utils.py
+++ b/pyoptsparse/pyOpt_utils.py
@@ -529,3 +529,13 @@ def _csc_to_coo(mat: dict) -> dict:
     coo_data = np.array(data)
 
     return {"coo": [coo_rows, coo_cols, coo_data], "shape": mat["shape"]}
+
+
+def _broadcast_to_array(name: str, value, n_vars: int, allow_none: bool = True):
+    try:
+        value = np.broadcast_to(value, (n_vars))
+    except ValueError:
+        raise Error(f"The '{name}' argument is invalid. It must be None, a scalar, or a list/array or length {n_vars}.")
+    if not allow_none and any([i is None for i in value]):
+        raise Error(f"The {name} argument cannot be 'None'.")
+    return value

--- a/pyoptsparse/types.py
+++ b/pyoptsparse/types.py
@@ -2,13 +2,14 @@
 from typing import Dict, List, Union
 
 # External modules
-from numpy import ndarray
+import numpy as np
+import numpy.typing as npt
 
 # Either ndarray or scalar
-NumpyType = Union[float, ndarray]
+NumpyType = Union[float, npt.NDArray[np.float_]]
 # ndarray, list of numbers, or scalar
-ArrayType = Union[float, List[float], ndarray]
+ArrayType = Union[NumpyType, List[float]]
 # funcs
-Dict1DType = Dict[str, ndarray]
+Dict1DType = Dict[str, npt.NDArray[np.float_]]
 # funcsSens
-Dict2DType = Dict[str, Dict[str, ndarray]]
+Dict2DType = Dict[str, Dict[str, npt.NDArray[np.float_]]]

--- a/pyoptsparse/types.py
+++ b/pyoptsparse/types.py
@@ -1,5 +1,5 @@
 # Standard Python modules
-from typing import Dict, List, Union
+from typing import Dict, Sequence, Union
 
 # External modules
 import numpy as np
@@ -8,7 +8,7 @@ import numpy.typing as npt
 # Either ndarray or scalar
 NumpyType = Union[float, npt.NDArray[np.float_]]
 # ndarray, list of numbers, or scalar
-ArrayType = Union[NumpyType, List[float]]
+ArrayType = Union[NumpyType, Sequence[float]]
 # funcs
 Dict1DType = Dict[str, npt.NDArray[np.float_]]
 # funcsSens


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
It's possible to have an unsized numpy array, e.g.
```
>>> x = np.array(5)
>>> x.shape
()
```
In such cases, the `isscalar` check fails:
```
>>> np.isscalar(np.array(5))
False
```

In this PR, I refactored this code into a utility function `_broadcast_to_array`, and switched to using `numpy.broadcast_to` which should work for all value types. This simplifies the code somewhat. I have commented below on things that may require attention in the review process.


## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
1-2 days.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
I did not add any tests.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
