### PR TITLE
Bugfix for optimal objective value

### DIFF
--- a/pyoptsparse/pyOpt_solution.py
+++ b/pyoptsparse/pyOpt_solution.py
@@ -34,7 +34,7 @@ class Solution(Optimization):
             in the Solution object.
         """
 
-        Optimization.__init__(self, optProb.name, None)
+        super().__init__(optProb.name, None)
 
         # Copy over the variables, constraints, and objectives
         self.variables = copy.deepcopy(optProb.variables)
@@ -43,10 +43,18 @@ class Solution(Optimization):
         xopt = optProb._mapXtoOpt(optProb.processXtoVec(xStar))
         # Now set the x-values:
         i = 0
-        for dvGroup in self.variables:
+        for dvGroup in self.variables.keys():
             for var in self.variables[dvGroup]:
                 var.value = xopt[i]
                 i += 1
+        i = 0
+        # Now set the f-values
+        if isinstance(fStar, float) or len(fStar) == 1:
+            self.objectives[list(self.objectives.keys())[0]].value = float(fStar)
+            fStar = float(fStar)
+        else:
+            for f_name, f in self.objectives.items():
+                f.value = fStar[f_name]
 
         self.optTime = info["optTime"]
         self.userObjTime = info["userObjTime"]

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -121,16 +121,14 @@ class OptTest(unittest.TestCase):
             self.sol_index = 0
         # now we assert against the closest solution
         # objective
-        # sol.fStar was broken for earlier versions of SNOPT
-        if self.optName == "SNOPT" and parse_version(self.optVersion) < parse_version("7.7.7"):
-            sol_objectives = np.array([sol.objectives[key].value for key in sol.objectives])
-        else:
-            sol_objectives = sol.fStar
-        assert_allclose(sol_objectives, self.fStar[self.sol_index], atol=tol, rtol=tol)
+        assert_allclose(sol.fStar, self.fStar[self.sol_index], atol=tol, rtol=tol)
+        # make sure fStar and sol.objectives values match
+        assert_allclose(sol.fStar, [obj.value for obj in sol.objectives.values()], rtol=1e-12)
         # x
         assert_dict_allclose(sol.xStar, self.xStar[self.sol_index], atol=tol, rtol=tol, partial=partial_x)
         dv = sol.getDVs()
         assert_dict_allclose(dv, self.xStar[self.sol_index], atol=tol, rtol=tol, partial=partial_x)
+        assert_dict_allclose(sol.xStar, dv, rtol=1e-12)
         # lambda
         if (
             hasattr(self, "lambdaStar")


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
Previously, `sol.fStar` is taken to be the optimal objective value, but `sol.objectives[obj_name].value` is the objective value of the last queried point, which is not guaranteed to match. This is now fixed, even though this is ambiguous and undocumented.

Note that the constraint values are still the last queried values, since the constraint value at the optimum is not returned by the optimizer and we do not want to query the constraints just to get this value. So they are left as the last value.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
1 week

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
I added a test

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
