### PR TITLE
fixed convertJacobian 

### DIFF
--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -665,7 +665,7 @@ class Optimizer(BaseSolver):
                     self._jac_map_csr_to_csc = mapToCSC(gcon_csr)
                 gcon = gcon_csr["csr"][IDATA][self._jac_map_csr_to_csc[IDATA]]
             elif self.jacType == "csr":
-                pass
+                gcon = gcon_csr["csr"][IDATA]
             elif self.jacType == "coo":
                 gcon = convertToCOO(gcon_csr)
                 gcon = gcon["coo"][IDATA]

--- a/pyoptsparse/pyParOpt/ParOpt.py
+++ b/pyoptsparse/pyParOpt/ParOpt.py
@@ -243,6 +243,8 @@ class ParOpt(Optimizer):
             # are switch since ParOpt uses a formulation with c(x) >= 0, while pyOpt
             # uses g(x) = -c(x) <= 0. Therefore the multipliers are reversed.
             sol_inform = {}
+            sol_inform["value"] = None
+            sol_inform["text"] = None
 
             # If number of constraints is zero, ParOpt returns z as None.
             # Thus if there is no constraints, should pass an empty list


### PR DESCRIPTION
call when jacType == "csr" so that it retuns CSR data instead of passing through

## Purpose
Minor bug fix

## Expected time until merged

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I checked it using ParOptSparse which requires the Jacobian matrix in a CSR structure

## Checklist

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
