### PR TITLE
Fix numpy 1.25 deprecation warnings

### DIFF
--- a/.github/test_real.sh
+++ b/.github/test_real.sh
@@ -11,4 +11,4 @@ cd tests
 # we have to copy over the coveragerc file to make sure it's in the
 # same directory where codecov is run
 cp ../.coveragerc .
-testflo --pre_announce -v --coverage --coverpkg pyoptsparse $EXTRA_FLAGS
+testflo --pre_announce --disallow_deprecations -v --coverage --coverpkg pyoptsparse $EXTRA_FLAGS

--- a/pyoptsparse/pyOpt_solution.py
+++ b/pyoptsparse/pyOpt_solution.py
@@ -1,6 +1,9 @@
 # Standard Python modules
 import copy
 
+# External modules
+import numpy as np
+
 # Local modules
 from .pyOpt_optimization import Optimization
 
@@ -49,9 +52,9 @@ class Solution(Optimization):
                 i += 1
 
         # Now set the f-values
-        if isinstance(fStar, float) or len(fStar) == 1:
-            self.objectives[list(self.objectives.keys())[0]].value = float(fStar.item())
-            fStar = float(fStar.item())
+        if isinstance(fStar, np.ndarray) and len(fStar) == 1:
+            self.objectives[list(self.objectives.keys())[0]].value = fStar.item()
+            fStar = fStar.item()
         else:
             for f_name, f in self.objectives.items():
                 f.value = fStar[f_name]

--- a/pyoptsparse/pyOpt_solution.py
+++ b/pyoptsparse/pyOpt_solution.py
@@ -50,8 +50,8 @@ class Solution(Optimization):
 
         # Now set the f-values
         if isinstance(fStar, float) or len(fStar) == 1:
-            self.objectives[list(self.objectives.keys())[0]].value = float(fStar)
-            fStar = float(fStar)
+            self.objectives[list(self.objectives.keys())[0]].value = float(fStar.item())
+            fStar = float(fStar.item())
         else:
             for f_name, f in self.objectives.items():
                 f.value = fStar[f_name]


### PR DESCRIPTION
## Purpose
Closes #368. In addition, added the `--disallow_deprecations` flag to avoid this happening again. For stable images to pass PR #370 needs to be merged first.

## Expected time until merged
Once tests pass, and after PR #370

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
