### PR TITLE
fix skip message

### DIFF
--- a/tests/test_user_termination.py
+++ b/tests/test_user_termination.py
@@ -126,7 +126,7 @@ class TestUserTerminationStatus(unittest.TestCase):
         try:
             opt = OPT(optName, options=optOptions)
         except ImportError:
-            raise unittest.SkipTest("Optimizer not available: SNOPT")
+            raise unittest.SkipTest(f"Optimizer not available: {optName}")
 
         sol = opt(optProb, sens=termcomp.sens)
 


### PR DESCRIPTION
## Purpose

This is a small fix to the message raised when this test is skipped.  The test is parameterized and could be testing one of two optimizers (IPOPT or SNOPT), but the message is hard coded to SNOPT.

```
/home/runner/work/pyoptsparse/pyoptsparse/tests/test_user_termination.py:TestUserTerminationStatus.test_obj_0_IPOPT  ... SKIP (00:00:0.00, 145 MB)
Optimizer not available: IPOPT
/home/runner/work/pyoptsparse/pyoptsparse/tests/test_user_termination.py:TestUserTerminationStatus.test_obj_1_SNOPT ... OK (00:00:0.01, 145 MB)
/home/runner/work/pyoptsparse/pyoptsparse/tests/test_user_termination.py:TestUserTerminationStatus.test_sens_0_IPOPT  ... SKIP (00:00:0.00, 145 MB)
Optimizer not available: SNOPT
/home/runner/work/pyoptsparse/pyoptsparse/tests/test_user_termination.py:TestUserTerminationStatus.test_sens_1_SNOPT ... OK (00:00:0.01, 145 MB)
```

## Expected time until merged

Not urgent. 

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing

When the test is run and IPOPT is not installed, the skip message should properly reflect that it was skipped due to IPOPT, not SNOPT:
```
/home/runner/work/pyoptsparse/pyoptsparse/tests/test_user_termination.py:TestUserTerminationStatus.test_sens_0_IPOPT  ... SKIP (00:00:0.00, 168 MB)
Optimizer not available: IPOPT
```

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
