### PR TITLE
Fix `_masterFunc2` fail flag caching and add fail flag identification to IPOPT

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -1,7 +1,7 @@
 dependencies:
 # build
   - python >=3.9
-  - numpy >=1.21
+  - numpy >=1.21,<2
   - ipopt
   - swig
   - meson >=1.3.2

--- a/pyoptsparse/__init__.py
+++ b/pyoptsparse/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.11.2"
+__version__ = "2.11.3"
 
 from .pyOpt_history import History
 from .pyOpt_variable import Variable

--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -91,7 +91,7 @@ class IPOPT(Optimizer):
             "sb": [str, "yes"],
             "print_user_options": [str, "yes"],
             "output_file": [str, "IPOPT.out"],
-            "linear_solver": [str, "ma86"],
+            "linear_solver": [str, "mumps"],
         }
         return defOpts
 

--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -217,19 +217,25 @@ class IPOPT(Optimizer):
             # Define the 4 call back functions that ipopt needs:
             def eval_f(x, user_data=None):
                 fobj, fail = self._masterFunc(x, ["fobj"])
-                if fail == 2:
+                if fail == 1:
+                    fobj = np.array(np.NaN)
+                elif fail == 2:
                     self.userRequestedTermination = True
                 return fobj
 
             def eval_g(x, user_data=None):
                 fcon, fail = self._masterFunc(x, ["fcon"])
-                if fail == 2:
+                if fail == 1:
+                    fcon = np.array(np.NaN)
+                elif fail == 2:
                     self.userRequestedTermination = True
                 return fcon.copy()
 
             def eval_grad_f(x, user_data=None):
                 gobj, fail = self._masterFunc(x, ["gobj"])
-                if fail == 2:
+                if fail == 1:
+                    gobj = np.array(np.NaN)
+                elif fail == 2:
                     self.userRequestedTermination = True
                 return gobj.copy()
 
@@ -238,7 +244,9 @@ class IPOPT(Optimizer):
                     return copy.deepcopy(matStruct)
                 else:
                     gcon, fail = self._masterFunc(x, ["gcon"])
-                    if fail == 2:
+                    if fail == 1:
+                        gcon = np.array(np.NaN)
+                    elif fail == 2:
                         self.userRequestedTermination = True
                     return gcon.copy()
 

--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -91,7 +91,7 @@ class IPOPT(Optimizer):
             "sb": [str, "yes"],
             "print_user_options": [str, "yes"],
             "output_file": [str, "IPOPT.out"],
-            "linear_solver": [str, "mumps"],
+            "linear_solver": [str, "ma86"],
         }
         return defOpts
 
@@ -161,7 +161,7 @@ class IPOPT(Optimizer):
 
         if len(optProb.constraints) == 0:
             # If the user *actually* has an unconstrained problem,
-            # snopt sort of chokes with that....it has to have at
+            # IPOPT sort of chokes with that....it has to have at
             # least one constraint. So we will add one
             # automatically here:
             self.unconstrained = True

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
         keywords="optimization",
         install_requires=[
             "sqlitedict>=1.6",
-            "numpy>=1.21",
+            "numpy>=1.21,<2",
             "scipy>=1.7",
             "mdolab-baseclasses>=1.3.1",
         ],

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -135,6 +135,44 @@ class TestOptimizer(unittest.TestCase):
         _, fail = self.opt._masterFunc(x, ["fobj"])
         self.assertTrue(fail)
 
+    def test_masterFunc_fobj_fail_cache(self):
+        """
+        Test that if the objective fails when _masterFunc is called
+        and it is then called again with the same x vector,
+        the fail flag is returned with the expected value.
+        """
+        nDV = [4]
+        self.setup_optProb(failFlag=(0, 100), nDV=nDV)
+
+        x = np.ones(np.sum(nDV), dtype=float)
+
+        # Fail
+        _, _, fail = self.opt._masterFunc(x, ["fcon", "fobj"])
+        self.assertTrue(fail)
+
+        # Should fail with the same x vector using the cache
+        _, fail = self.opt._masterFunc(x, ["fobj"])
+        self.assertTrue(fail)
+
+    def test_masterFunc_gobj_fail_cache(self):
+        """
+        Test that if the gradient fails when _masterFunc is called
+        and it is then called again with the same x vector,
+        the fail flag is returned with the expected value.
+        """
+        nDV = [4]
+        self.setup_optProb(failFlag=(0, 100), nDV=nDV)
+
+        x = np.ones(np.sum(nDV), dtype=float)
+
+        # Fail
+        _, _, fail = self.opt._masterFunc(x, ["gcon", "gobj"])
+        self.assertTrue(fail)
+
+        # Should fail with the same x vector using the cache
+        _, fail = self.opt._masterFunc(x, ["gobj"])
+        self.assertTrue(fail)
+
     def test_masterFunc_fobj_fcon_cache_fail(self):
         """
         Test that if the objective fails when _masterFunc is called

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -20,6 +20,7 @@ class TestOptimizer(unittest.TestCase):
         """
         # Initialize iters to infinite so the fail flag is never thrown on setup
         iters = np.inf
+
         def objfunc(xdict):
             """
             This is a simple quadratic test function with linear constraints.
@@ -43,7 +44,7 @@ class TestOptimizer(unittest.TestCase):
                 for x in xdict.keys():
                     for j in range(nc):
                         funcs[conName][j] = (iCon + 1) * np.sum(xdict[x])
-            
+
             # Throw the fail flag if it's in the specified range or True
             nonlocal iters
             if isinstance(failFlag, tuple):

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -159,6 +159,10 @@ class TestOptimizer(unittest.TestCase):
         _, fail = self.opt._masterFunc(x, [output])
         self.assertTrue(fail)
 
+        # Do the same thing one more time to make sure the cache is really really working
+        _, fail = self.opt._masterFunc(x, [output])
+        self.assertTrue(fail)
+
     def test_masterFunc_gobj_fail_cache(self):
         """
         Test that if the gradient fails when _masterFunc is called

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,221 @@
+"""Test for Optimizer"""
+
+# Standard Python modules
+import unittest
+
+# External modules
+import numpy as np
+
+# First party modules
+from pyoptsparse import OPT, Optimization
+
+
+class TestOptimizer(unittest.TestCase):
+    tol = 1e-12
+
+    def get_objfunc(self, failFlag=False):
+        """
+        Return an objfunc callable function where we can choose whether
+        the fail flag will be returned as True or False.
+        """
+        # Initialize iters to infinite so the fail flag is never thrown on setup
+        iters = np.inf
+        def objfunc(xdict):
+            """
+            This is a simple quadratic test function with linear constraints.
+            The actual problem doesn't really matter, since we are not testing optimization,
+            but just optProb. However, we need to initialize and run an optimization
+            in order to have optimizer-specific fields in optProb populated, such as
+            jacIndices.
+
+            This problem is probably not feasible, but that's okay.
+
+            Reset the iteration counter with a special call that includes
+            a nonfinite value in the design variable vector.
+            """
+            funcs = {}
+            funcs["obj_0"] = 0
+            for x in xdict.keys():
+                funcs["obj_0"] += np.sum(np.power(xdict[x], 2))
+            for iCon, nc in enumerate(self.nCon):
+                conName = f"con_{iCon}"
+                funcs[conName] = np.zeros(nc)
+                for x in xdict.keys():
+                    for j in range(nc):
+                        funcs[conName][j] = (iCon + 1) * np.sum(xdict[x])
+            
+            # Throw the fail flag if it's in the specified range or True
+            nonlocal iters
+            if isinstance(failFlag, tuple):
+                if not len(failFlag) == 2:
+                    raise ValueError("Fail flag must be a tuple of (iter start fail, iter end fail) or a boolean")
+                if failFlag[0] <= iters < failFlag[1]:
+                    fail = True
+                else:
+                    fail = False
+            elif isinstance(failFlag, bool):
+                fail = failFlag
+            else:
+                raise ValueError("Fail flag must be a tuple of (iter start fail, iter end fail) or a boolean")
+            iters += 1
+
+            # Reset iteration counter if any non-finite values in DV dict
+            for xVec in xdict.values():
+                if not np.all(np.isfinite(xVec)):
+                    iters = 0
+                    break
+            return funcs, fail
+
+        return objfunc
+
+    def setup_optProb(self, failFlag=False, nObj=1, nDV=[4], nCon=[2]):
+        """
+        This function sets up a general optimization problem, with arbitrary
+        DVs, constraints and objectives.
+        Arbitrary scaling for the various parameters can also be specified.
+        """
+        self.nObj = nObj
+        self.nDV = nDV
+        self.nCon = nCon
+
+        # Optimization Object
+        self.optProb = Optimization("Configurable Test Problem", self.get_objfunc(failFlag=failFlag))
+        self.x0 = {}
+        # Design Variables
+        for iDV in range(len(nDV)):
+            n = nDV[iDV]
+            x0 = np.ones(n)
+            dvName = f"x{iDV}"
+            self.x0[dvName] = x0
+            self.optProb.addVarGroup(
+                dvName,
+                n,
+                lower=-1,
+                upper=1,
+                value=x0,
+            )
+
+        # Constraints
+        for iCon in range(len(nCon)):
+            nc = nCon[iCon]
+            self.optProb.addConGroup(
+                f"con_{iCon}",
+                nc,
+                lower=-5,
+                upper=5,
+            )
+
+        # Objective
+        for iObj in range(nObj):
+            self.optProb.addObj(f"obj_{iObj}")
+
+        # Finalize
+        self.optProb.printSparsity()
+        # create and store optimizer
+        self.opt = OPT("slsqp", options={"IFILE": "optProb_SLSQP.out"})
+        self.opt(self.optProb, sens="FD")
+
+        # Call the masterFunc with some infinite DVs so it resets iters
+        self.opt._masterFunc(np.full(np.sum(nDV), np.inf), ["fobj"])
+
+    def test_masterFunc_fobj_fail(self):
+        """
+        Test that if the objective fails when _masterFunc is called,
+        the fail flag is returned with the expected value.
+        """
+        nDV = [4]
+        self.setup_optProb(failFlag=(1, 100), nDV=nDV)
+
+        x = np.ones(np.sum(nDV), dtype=float)
+
+        # Do not fail
+        _, fail = self.opt._masterFunc(x, ["fobj"])
+        self.assertFalse(fail)
+
+        # Should fail on the second function call
+        x += 1  # change x so it doesn't use the cache
+        _, fail = self.opt._masterFunc(x, ["fobj"])
+        self.assertTrue(fail)
+
+    def test_masterFunc_fobj_fcon_cache_fail(self):
+        """
+        Test that if the objective fails when _masterFunc is called
+        and then the constraints are called, it still returns a failure.
+        """
+        nDV = [4]
+        self.setup_optProb(failFlag=(1, 100), nDV=nDV)
+
+        x = np.ones(np.sum(nDV), dtype=float)
+
+        # Do not fail
+        _, fail = self.opt._masterFunc(x, ["fobj"])
+        self.assertFalse(fail)
+
+        # Check that the cached value does not fail either
+        _, fail = self.opt._masterFunc(x, ["fcon"])
+        self.assertFalse(fail)
+
+        # Should fail on the second function call
+        x += 1  # change x so it doesn't use the cache
+        _, fail = self.opt._masterFunc(x, ["fobj"])
+        self.assertTrue(fail)
+
+        # Check that the cached value now fails too
+        _, fail = self.opt._masterFunc(x, ["fcon"])
+        self.assertTrue(fail)
+
+    def test_masterFunc_fail_then_success(self):
+        """
+        Test that if the objective/constraint fails when _masterFunc is called
+        and then it succeeds, the fail flag is no longer true.
+        """
+        nDV = [4, 5]
+        self.setup_optProb(failFlag=(0, 1), nDV=nDV)
+
+        x = np.ones(np.sum(nDV), dtype=float)
+
+        # Fail
+        _, _, fail = self.opt._masterFunc(x, ["fobj", "fcon"])
+        self.assertTrue(fail)
+
+        # Should succeed on the second call
+        x += 1  # change x so it doesn't use the cache
+        _, _, fail = self.opt._masterFunc(x, ["fobj", "fcon"])
+        self.assertFalse(fail)
+
+    def test_masterFunc_fail_grad_after_fail_func(self):
+        """
+        Test that if the _masterFunc is called to compute the gradients on
+        an x that isn't in the cache and the primal fails, it returns a
+        fail flag for the gradient too.
+        """
+        nDV = [4, 5]
+        self.setup_optProb(failFlag=(0, 1), nDV=nDV)
+
+        x = np.ones(np.sum(nDV), dtype=float) + 5
+
+        # Fail
+        _, _, fail = self.opt._masterFunc(x, ["gobj", "gcon"])
+        self.assertTrue(fail)
+
+    def test_masterFunc_succeed_grad_after_fail_func(self):
+        """
+        Test that if the _masterFunc is called to compute the gradients on
+        an x that is in the cache and the primal fails, it returns a
+        False fail flag for the gradient.
+        """
+        nDV = [4, 5]
+        self.setup_optProb(failFlag=(0, 1), nDV=nDV)
+
+        x = np.ones(np.sum(nDV), dtype=float) + 5
+
+        _, fail = self.opt._masterFunc(x, ["fobj"])  # call primal to put x in the cache
+        self.assertTrue(fail)
+
+        # Gradient succeeds even though primal failed
+        _, _, fail = self.opt._masterFunc(x, ["gobj", "gcon"])
+        self.assertFalse(fail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -12,6 +12,7 @@ from pyoptsparse import OPT, Optimization
 
 MASTERFUNC_OUTPUTS = ["fobj", "fcon", "gobj", "gcon"]
 
+
 class TestOptimizer(unittest.TestCase):
     tol = 1e-12
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -188,12 +188,17 @@ class TestOptimizer(unittest.TestCase):
         fail flag for the gradient too.
         """
         nDV = [4, 5]
-        self.setup_optProb(failFlag=(0, 1), nDV=nDV)
+        self.setup_optProb(failFlag=(0, 1000), nDV=nDV)
 
         x = np.ones(np.sum(nDV), dtype=float) + 5
 
-        # Fail
-        _, _, fail = self.opt._masterFunc(x, ["gobj", "gcon"])
+        # Fail obj gradient on DVs that haven't been evaluated
+        _, fail = self.opt._masterFunc(x, ["gobj"])
+        self.assertTrue(fail)
+
+        # Fail con gradient on DVs that haven't been evaluated
+        x += 1
+        _, fail = self.opt._masterFunc(x, ["gcon"])
         self.assertTrue(fail)
 
     def test_masterFunc_succeed_grad_after_fail_func(self):

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -49,10 +49,7 @@ class TestOptimizer(unittest.TestCase):
             if isinstance(failFlag, tuple):
                 if not len(failFlag) == 2:
                     raise ValueError("Fail flag must be a tuple of (iter start fail, iter end fail) or a boolean")
-                if failFlag[0] <= iters < failFlag[1]:
-                    fail = True
-                else:
-                    fail = False
+                fail = failFlag[0] <= iters < failFlag[1]
             elif isinstance(failFlag, bool):
                 fail = failFlag
             else:


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
Some optimizers don't simultaneously call `_masterFunc` with the objective and constraint evaluation. In these cases, if the primal fails, the fail flag will only return the accurate value when the cache is not used (the case that actually calls the objective/constraint function). When the cache is used, the fail flag is always returned as `0`. A similar behavior occurs with the gradient evaluation. This PR caches the fail flag to fix this edge case.

Secondly, the pyIPOPT wrapper does not do anything if the `_masterFunc` returns a `True` fail flag (`1`). Even if any of the functions fail, IPOPT will just push on as if nothing happened. A CFD-based optimization case I saw with this was that it would get a mesh failure, immediately evaluate the gradients, go straight back to a mesh failure, and so on. The output file was as if nothing had failed and everything was normal. This is clearly not what should happen. I solved it by returning `np.array(np.NaN)` in the callback functions if `fail == 1`.

There are two changes in particular that I'd like feedback on:

1. There's a certain rare logic branch: the gradients are evaluated for a design variable vector at which the primal has not been evaluated. In this case, `_masterFunc2` calls itself to evaluate the primal first. In the current pyOptSparse implementation, if this primal fails, that failure is totally ignored. I modified it so that if the primal fails in this case, the gradient `_masterFunc2` evaluation will return that failure value, even if the gradient evaluation succeeds. See lines 452--458 and 511-517 of the new code. Is this the right thing to do?
2. The only way I could figure out to tell IPOPT that the evaluation failed is to return `np.array(np.NaN)` in whatever callback function is called. I don't see any more elegant way based on their docs. Although the shape isn't guaranteed to match the function's usual array shape, it appears to work based on my test cases. Does this seem like a reasonable way to solve this problem?

P.S. should I update the patch version?

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
A week

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
Run the tests I added. Also try running a simple IPOPT optimization case where some of the functions periodically fail. It should backtrack properly (it would just ignore the fail flag previously). For example:

```python
import numpy as np
from pyoptsparse import Optimization, OPT

iters = 0
def objfunc(xdict):
    x = xdict["xvars"]
    funcs = {"obj": x[0]**2 + np.sin(x[0] - 0.5)}

    # Fail every fourth iteration
    global iters
    fail = iters % 4 == 2
    iters += 1

    return funcs, fail

def sensfunc(xdict, funcsDict):
    x = xdict["xvars"]  # Extract array
    funcsSens = {"obj": {"xvars": [2 * x[0] + np.cos(x[0] - 0.5)]}}
    fail = False
    return funcsSens, fail

# Instantiate Optimization Problem
optProb = Optimization("Optimization problem", objfunc)
optProb.addVarGroup("xvars", 1, "c", value=3, scale=1.0)
optProb.addObj("obj")

# Create optimizer
opt = OPT("IPOPT", options={})
sol = opt(optProb, sens=sensfunc)
```

The IPOPT output should look something like this (note the alpha cutback warnings, which do not appear with the current implementation):
```
iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
   0  9.5984721e+00 0.00e+00 5.20e+00   0.0 0.00e+00    -  0.00e+00 0.00e+00   0
   1  4.4065559e+00 0.00e+00 5.30e+00 -11.0 5.20e+00    -  1.00e+00 1.00e+00f  1
Warning: Cutting back alpha due to evaluation error
   2 -1.9724310e-01 0.00e+00 1.59e+00 -11.0 2.62e+00    -  1.00e+00 5.00e-01f  2
   3 -6.2890484e-01 0.00e+00 3.02e-02 -11.0 5.62e-01    -  1.00e+00 1.00e+00f  1
   4 -6.2907135e-01 0.00e+00 1.51e-03 -11.0 1.05e-02    -  1.00e+00 1.00e+00f  1
Warning: Cutting back alpha due to evaluation error
   5 -6.2907166e-01 0.00e+00 7.55e-04 -11.0 5.53e-04    -  1.00e+00 5.00e-01f  2
   6 -6.2907176e-01 0.00e+00 5.10e-08 -11.0 2.76e-04    -  1.00e+00 1.00e+00f  1
   7 -6.2907176e-01 0.00e+00 1.72e-12 -11.0 1.86e-08    -  1.00e+00 1.00e+00f  1
```

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
