### PR TITLE
Strongly enforce SLSQP Bounds

### DIFF
--- a/pyoptsparse/pySLSQP/pySLSQP.py
+++ b/pyoptsparse/pySLSQP/pySLSQP.py
@@ -7,7 +7,7 @@ work with sparse optimization problems.
 import datetime
 import os
 import time
-import warnings
+from ..pyOpt_error import pyOptSparseWarning
 
 # External modules
 import numpy as np
@@ -168,8 +168,8 @@ class SLSQP(Optimizer):
             # =================================================================
             def slfunc(m, me, la, n, f, g, x):
                 if (x < blx).any() or (x > bux).any():
-                    warnings.warn("Values in x were outside bounds during a "
-                                  "minimize step, clipping to bounds", RuntimeWarning)
+                    pyOptSparseWarning("Values in x were outside bounds during"
+                                       " a minimize step, clipping to bounds")YY
                 fobj, fcon, fail = self._masterFunc(np.clip(x, blx, bux), ["fobj", "fcon"])
                 f = fobj
                 g[0:m] = -fcon

--- a/pyoptsparse/pySLSQP/pySLSQP.py
+++ b/pyoptsparse/pySLSQP/pySLSQP.py
@@ -169,7 +169,7 @@ class SLSQP(Optimizer):
             def slfunc(m, me, la, n, f, g, x):
                 if (x < blx).any() or (x > bux).any():
                     pyOptSparseWarning("Values in x were outside bounds during"
-                                       " a minimize step, clipping to bounds")YY
+                                       " a minimize step, clipping to bounds")
                 fobj, fcon, fail = self._masterFunc(np.clip(x, blx, bux), ["fobj", "fcon"])
                 f = fobj
                 g[0:m] = -fcon

--- a/pyoptsparse/pySLSQP/pySLSQP.py
+++ b/pyoptsparse/pySLSQP/pySLSQP.py
@@ -7,6 +7,7 @@ work with sparse optimization problems.
 import datetime
 import os
 import time
+import warnings
 
 # External modules
 import numpy as np
@@ -166,6 +167,9 @@ class SLSQP(Optimizer):
             # SLSQP - Objective/Constraint Values Function
             # =================================================================
             def slfunc(m, me, la, n, f, g, x):
+                if (x < blx).any() or (x > bux).any():
+                    warnings.warn("Values in x were outside bounds during a "
+                                  "minimize step, clipping to bounds", RuntimeWarning)
                 fobj, fcon, fail = self._masterFunc(np.clip(x, blx, bux), ["fobj", "fcon"])
                 f = fobj
                 g[0:m] = -fcon

--- a/pyoptsparse/pySLSQP/pySLSQP.py
+++ b/pyoptsparse/pySLSQP/pySLSQP.py
@@ -220,6 +220,10 @@ class SLSQP(Optimizer):
             # fmt: on
             optTime = time.time() - t0
 
+            # Clip final result to user bounds (this occurs during the optimization as well
+            # so this just makes the output consistent with what the optimizer sees)
+            xs = np.clip(xs, blx, bux)
+
             # some entries of W include the lagrange multipliers
             # for each constraint, there are two entries (lower, upper).
             # if only one is active, look for the nonzero. If both are active, take the first one

--- a/pyoptsparse/pySLSQP/pySLSQP.py
+++ b/pyoptsparse/pySLSQP/pySLSQP.py
@@ -166,7 +166,7 @@ class SLSQP(Optimizer):
             # SLSQP - Objective/Constraint Values Function
             # =================================================================
             def slfunc(m, me, la, n, f, g, x):
-                fobj, fcon, fail = self._masterFunc(x, ["fobj", "fcon"])
+                fobj, fcon, fail = self._masterFunc(np.clip(x, blx, bux), ["fobj", "fcon"])
                 f = fobj
                 g[0:m] = -fcon
                 slsqp.pyflush(self.getOption("IOUT"))
@@ -176,7 +176,7 @@ class SLSQP(Optimizer):
             # SLSQP - Objective/Constraint Gradients Function
             # =================================================================
             def slgrad(m, me, la, n, f, g, df, dg, x):
-                gobj, gcon, fail = self._masterFunc(x, ["gobj", "gcon"])
+                gobj, gcon, fail = self._masterFunc(np.clip(x, blx, bux), ["gobj", "gcon"])
                 df[0:n] = gobj.copy()
                 dg[0:m, 0:n] = -gcon.copy()
                 slsqp.pyflush(self.getOption("IOUT"))

--- a/pyoptsparse/pySLSQP/pySLSQP.py
+++ b/pyoptsparse/pySLSQP/pySLSQP.py
@@ -7,12 +7,12 @@ work with sparse optimization problems.
 import datetime
 import os
 import time
-from ..pyOpt_error import pyOptSparseWarning
 
 # External modules
 import numpy as np
 
 # Local modules
+from ..pyOpt_error import pyOptSparseWarning
 from ..pyOpt_optimizer import Optimizer
 from ..pyOpt_utils import try_import_compiled_module_from_path
 
@@ -168,8 +168,7 @@ class SLSQP(Optimizer):
             # =================================================================
             def slfunc(m, me, la, n, f, g, x):
                 if (x < blx).any() or (x > bux).any():
-                    pyOptSparseWarning("Values in x were outside bounds during"
-                                       " a minimize step, clipping to bounds")
+                    pyOptSparseWarning("Values in x were outside bounds during" " a minimize step, clipping to bounds")
                 fobj, fcon, fail = self._masterFunc(np.clip(x, blx, bux), ["fobj", "fcon"])
                 f = fobj
                 g[0:m] = -fcon

--- a/pyoptsparse/pySLSQP/source/lsq.f
+++ b/pyoptsparse/pySLSQP/source/lsq.f
@@ -177,8 +177,20 @@ c   restore Lagrange multipliers
           CALL DCOPY (N3, W(IW+M+N), 1, Y(M+N3+1), 1)
 
       ENDIF
+      call bound(n, x, xl, xu)
 
 C   END OF SUBROUTINE LSQ
 
       END
-      
+
+      subroutine bound(n, x, xl, xu)
+      integer n, i
+      double precision x(n), xl(n), xu(n)
+      do i = 1, n
+         if(x(i) < xl(i))then
+            x(i) = xl(i)
+         else if(x(i) > xu(i))then
+            x(i) = xu(i)
+         end if
+      end do
+      end subroutine bound

--- a/tests/test_slsqp.py
+++ b/tests/test_slsqp.py
@@ -1,0 +1,47 @@
+"""Test class for SLSQP specific tests"""
+
+# First party modules
+from pyoptsparse import Optimization, OPT
+
+# Local modules
+from testing_utils import OptTest
+
+
+class TestSLSQP(OptTest):
+
+    def test_slsqp_strong_bound_enforcement(self):
+        """
+        Test that SLSQP will never evaluate the function or gradient outside
+        the design variable bounds. Without strong bound enforcement, the
+        optimizer will step outside the bounds and a ValueError will be raised.
+        With strong bound enforement, this code will run without raising any
+        errors
+        """
+
+        def objfunc(xdict):
+            x = xdict["xvars"]
+            funcs = {}
+            if x[0] < 0:
+                raise ValueError("Function cannot be evaluated below 0.")
+            funcs["obj"] = (x[0] - 1.0) ** 2
+            fail = False
+            return funcs, fail
+
+        def sens(xdict, funcs):
+            x = xdict["xvars"]
+            if x[0] < 0:
+                raise ValueError("Function cannot be evaluated below 0.")
+            funcsSens = {
+                "obj": {"xvars": [2 * (x[0] + 1.0)]},
+            }
+            fail = False
+            return funcsSens, fail
+
+        optProb = Optimization("Problem with Error Region", objfunc)
+        optProb.addVarGroup("xvars", 1, lower=[0], value=[2])
+        optProb.addObj("obj")
+        opt = OPT("SLSQP")
+        sol = opt(optProb, sens=sens)
+        self.assertEqual(sol.optInform["value"], 0)
+        self.assertGreaterEqual(sol.xStar["xvars"][0], 0)
+        self.assertAlmostEqual(sol.xStar["xvars"][0], 0, places=9)

--- a/tests/test_slsqp.py
+++ b/tests/test_slsqp.py
@@ -1,12 +1,13 @@
 """Test class for SLSQP specific tests"""
 
-# First party modules
-from pyoptsparse import Optimization, OPT
+# Standard Python modules
 import unittest
+
+# First party modules
+from pyoptsparse import OPT, Optimization
 
 
 class TestSLSQP(unittest.TestCase):
-
     def test_slsqp_strong_bound_enforcement(self):
         """
         Test that SLSQP will never evaluate the function or gradient outside

--- a/tests/test_slsqp.py
+++ b/tests/test_slsqp.py
@@ -2,12 +2,10 @@
 
 # First party modules
 from pyoptsparse import Optimization, OPT
-
-# Local modules
-from testing_utils import OptTest
+import unittest
 
 
-class TestSLSQP(OptTest):
+class TestSLSQP(unittest.TestCase):
 
     def test_slsqp_strong_bound_enforcement(self):
         """

--- a/tests/test_slsqp.py
+++ b/tests/test_slsqp.py
@@ -21,7 +21,7 @@ class TestSLSQP(unittest.TestCase):
             funcs = {}
             if x[0] < 0:
                 raise ValueError("Function cannot be evaluated below 0.")
-            funcs["obj"] = (x[0] - 1.0) ** 2
+            funcs["obj"] = (x[0] + 1.0) ** 2
             fail = False
             return funcs, fail
 


### PR DESCRIPTION
## Purpose
One of the key differences between the pyOptSparse SLSQP implementation and the SciPy SLSQP implementation is strong bound enforcement. This was added the the SciPy implementation in these two PRs

https://github.com/scipy/scipy/pull/4502
https://github.com/scipy/scipy/pull/13009

These changes are fairly small and easy enough to port over. I've proposed this with this PR. This I suppose should fix #301 and relate to #303.

## Expected time until merged
This is not overly pressing, but my team uses OpenMDAO with the SciPy SLSQP rather than the pyOptSparse driver due to bound enforcement issues, so this will allow us to shift over to pyOptSparse once merged.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
I ran the hs015.py example and brought the initial guess outside to the bounds.

## Checklist

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
