### PR TITLE
IPOPT now returns Lagrange multpliers using the same sign convention as SNOPT.

### DIFF
--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -296,7 +296,7 @@ class IPOPT(Optimizer):
             sol_inform["text"] = self.informs[status]
 
             # Create the optimization solution
-            sol = self._createSolution(optTime, sol_inform, obj, x, multipliers=-constraint_multipliers)
+            sol = self._createSolution(optTime, sol_inform, obj, x, multipliers=constraint_multipliers)
 
             # Indicate solution finished
             self.optProb.comm.bcast(-1, root=0)

--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -296,7 +296,7 @@ class IPOPT(Optimizer):
             sol_inform["text"] = self.informs[status]
 
             # Create the optimization solution
-            sol = self._createSolution(optTime, sol_inform, obj, x)
+            sol = self._createSolution(optTime, sol_inform, obj, x, multipliers=-constraint_multipliers)
 
             # Indicate solution finished
             self.optProb.comm.bcast(-1, root=0)

--- a/pyoptsparse/pyOpt_optimization.py
+++ b/pyoptsparse/pyOpt_optimization.py
@@ -1577,7 +1577,7 @@ class Optimization:
         con_opt = self._mapContoOpt(con)
         return self.processContoDict(con_opt, scaled=False, natural=True)
 
-    def summary_str(self, minimal_print=False):
+    def summary_str(self, minimal_print=False, print_multipliers=False):
         """
         Print Structured Optimization Problem
 
@@ -1588,6 +1588,8 @@ class Optimization:
             variables and constraints with a non-empty status
             (for example a violated bound).
             This defaults to False, which will print all results.
+        print_multipliers : bool
+            If True, print the Lagrange multipliers associated with the constraints.
         """
         TOL = 1.0e-6
 
@@ -1656,7 +1658,7 @@ class Optimization:
 
         if len(self.constraints) > 0:
             # must be an instance of the Solution class
-            if not isinstance(self, Optimization) and self.lambdaStar is not None:
+            if print_multipliers and self.lambdaStar is not None:
                 lambdaStar = self.lambdaStar
                 lambdaStar_label = "Lagrange Multiplier"
             else:
@@ -1716,7 +1718,7 @@ class Optimization:
         return text
 
     def __str__(self):
-        return self.summary_str(minimal_print=False)
+        return self.summary_str(minimal_print=False, print_multipliers=False)
 
     def __getstate__(self) -> dict:
         """

--- a/pyoptsparse/pyOpt_solution.py
+++ b/pyoptsparse/pyOpt_solution.py
@@ -75,7 +75,7 @@ class Solution(Optimization):
         """
         Print Structured Solution
         """
-        text0 = super().__str__()
+        text0 = self.summary_str(minimal_print=False, print_multipliers=True)
         text1 = ""
         lines = text0.split("\n")
         lines[1] = lines[1][len("Optimization Problem -- ") :]

--- a/tests/test_hs071.py
+++ b/tests/test_hs071.py
@@ -220,7 +220,7 @@ class TestHS71(OptTest):
         con2_line_num = constraint_header_line_num + 3
         lambda_con1 = float(lines[con1_line_num].split()[-1])
         lambda_con2 = float(lines[con2_line_num].split()[-1])
-        if optName in ("IPOPT", "SNOPT"):
+        if optName in ("IPOPT", "SNOPT", "ParOpt"):
             assert_allclose([lambda_con1, lambda_con2], self.lambdaStar[0]["con"], rtol=1.0E-5, atol=1.0E-5)
         else:
             assert_allclose([lambda_con1, lambda_con2], [9.E100, 9.E100], rtol=1.0E-5, atol=1.0E-5)

--- a/tests/test_hs071.py
+++ b/tests/test_hs071.py
@@ -222,10 +222,14 @@ class TestHS71(OptTest):
         lambda_con1 = float(lines[con1_line_num].split()[-1])
         lambda_con2 = float(lines[con2_line_num].split()[-1])
         if optName in ("IPOPT", "SNOPT", "ParOpt"):
-            lambda_sign = -1.0 if optName == 'IPOPT' else 1.0
-            assert_allclose([lambda_con1, lambda_con2],
-                            lambda_sign * np.asarray(self.lambdaStar[0]["con"]),
-                            rtol=1.0e-5, atol=1.0e-5)
+            # IPOPT returns Lagrange multipliers with opposite sign than SNOPT and ParOpt
+            lambda_sign = -1.0 if optName == "IPOPT" else 1.0
+            assert_allclose(
+                [lambda_con1, lambda_con2],
+                lambda_sign * np.asarray(self.lambdaStar[0]["con"]),
+                rtol=1.0e-5,
+                atol=1.0e-5,
+            )
         else:
             assert_allclose([lambda_con1, lambda_con2], [9.0e100, 9.0e100], rtol=1.0e-5, atol=1.0e-5)
 

--- a/tests/test_hs071.py
+++ b/tests/test_hs071.py
@@ -213,6 +213,17 @@ class TestHS71(OptTest):
         self.assert_solution_allclose(sol, self.tol[optName])
         # Check informs
         self.assert_inform_equal(sol)
+        # Check the lagrange multipliers in the solution text
+        lines = str(sol).split('\n')
+        constraint_header_line_num = [i for i, line in enumerate(lines) if "Constraints" in line][0]
+        con1_line_num = constraint_header_line_num + 2
+        con2_line_num = constraint_header_line_num + 3
+        lambda_con1 = float(lines[con1_line_num].split()[-1])
+        lambda_con2 = float(lines[con2_line_num].split()[-1])
+        if optName in ("IPOPT", "SNOPT"):
+            assert_allclose([lambda_con1, lambda_con2], self.lambdaStar[0]["con"], rtol=1.0E-5, atol=1.0E-5)
+        else:
+            assert_allclose([lambda_con1, lambda_con2], [9.E100, 9.E100], rtol=1.0E-5, atol=1.0E-5)
 
 
 if __name__ == "__main__":

--- a/tests/test_hs071.py
+++ b/tests/test_hs071.py
@@ -210,7 +210,8 @@ class TestHS71(OptTest):
         optOptions = self.optOptions.pop(optName, None)
         sol = self.optimize(optOptions=optOptions)
         # Check Solution
-        self.assert_solution_allclose(sol, self.tol[optName])
+        lambda_sign = -1.0 if optName == "IPOPT" else 1.0
+        self.assert_solution_allclose(sol, self.tol[optName], lambda_sign=lambda_sign)
         # Check informs
         self.assert_inform_equal(sol)
         # Check the lagrange multipliers in the solution text
@@ -221,7 +222,10 @@ class TestHS71(OptTest):
         lambda_con1 = float(lines[con1_line_num].split()[-1])
         lambda_con2 = float(lines[con2_line_num].split()[-1])
         if optName in ("IPOPT", "SNOPT", "ParOpt"):
-            assert_allclose([lambda_con1, lambda_con2], self.lambdaStar[0]["con"], rtol=1.0e-5, atol=1.0e-5)
+            lambda_sign = -1.0 if optName == 'IPOPT' else 1.0
+            assert_allclose([lambda_con1, lambda_con2],
+                            lambda_sign * np.asarray(self.lambdaStar[0]["con"]),
+                            rtol=1.0e-5, atol=1.0e-5)
         else:
             assert_allclose([lambda_con1, lambda_con2], [9.0e100, 9.0e100], rtol=1.0e-5, atol=1.0e-5)
 

--- a/tests/test_hs071.py
+++ b/tests/test_hs071.py
@@ -214,16 +214,16 @@ class TestHS71(OptTest):
         # Check informs
         self.assert_inform_equal(sol)
         # Check the lagrange multipliers in the solution text
-        lines = str(sol).split('\n')
+        lines = str(sol).split("\n")
         constraint_header_line_num = [i for i, line in enumerate(lines) if "Constraints" in line][0]
         con1_line_num = constraint_header_line_num + 2
         con2_line_num = constraint_header_line_num + 3
         lambda_con1 = float(lines[con1_line_num].split()[-1])
         lambda_con2 = float(lines[con2_line_num].split()[-1])
         if optName in ("IPOPT", "SNOPT", "ParOpt"):
-            assert_allclose([lambda_con1, lambda_con2], self.lambdaStar[0]["con"], rtol=1.0E-5, atol=1.0E-5)
+            assert_allclose([lambda_con1, lambda_con2], self.lambdaStar[0]["con"], rtol=1.0e-5, atol=1.0e-5)
         else:
-            assert_allclose([lambda_con1, lambda_con2], [9.E100, 9.E100], rtol=1.0E-5, atol=1.0E-5)
+            assert_allclose([lambda_con1, lambda_con2], [9.0e100, 9.0e100], rtol=1.0e-5, atol=1.0e-5)
 
 
 if __name__ == "__main__":

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -144,9 +144,7 @@ class OptTest(unittest.TestCase):
             and sol.lambdaStar is not None
         ):
             lamStar = {con: lambda_sign * lam for con, lam in sol.lambdaStar.items()}
-            assert_dict_allclose(lamStar,
-                                 self.lambdaStar[self.sol_index],
-                                 atol=tol, rtol=tol)
+            assert_dict_allclose(lamStar, self.lambdaStar[self.sol_index], atol=tol, rtol=tol)
 
         # test printing solution
         print(sol)

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -85,7 +85,7 @@ class OptTest(unittest.TestCase):
     def setUp(self):
         self.histFileName = None
 
-    def assert_solution_allclose(self, sol, tol, partial_x=False):
+    def assert_solution_allclose(self, sol, tol, partial_x=False, lambda_sign=1.0):
         """
         An assertion method to check that the solution object matches the expected
         optimum values defined in the class.
@@ -100,6 +100,10 @@ class OptTest(unittest.TestCase):
             Whether partial assertion of the design variables ``x`` is allowed.
             For large problems, we may not have the full x vector available at the optimum,
             so we only check a few entries.
+        lambda_sign : float
+            The sign of the Lagrange multipliers returned by the optimizer. By convention,
+            SNOPT and ParOpt return a sign that agrees with the test data, while IPOPT
+            returns the opposite sign.
         """
         if not isinstance(self.xStar, list):
             self.xStar = [self.xStar]
@@ -139,7 +143,10 @@ class OptTest(unittest.TestCase):
             and self.lambdaStar is not None
             and sol.lambdaStar is not None
         ):
-            assert_dict_allclose(sol.lambdaStar, self.lambdaStar[self.sol_index], atol=tol, rtol=tol)
+            lamStar = {con: lambda_sign * lam for con, lam in sol.lambdaStar.items()}
+            assert_dict_allclose(lamStar,
+                                 self.lambdaStar[self.sol_index],
+                                 atol=tol, rtol=tol)
 
         # test printing solution
         print(sol)


### PR DESCRIPTION
## Purpose

Added lagrange multipliers to IPOPT's output. Note that in the call to _createSolution we negate the multiplier values so that they are consistent with those returned by SNOPT. My understanding is that this is a matter of convention (due to the internal representations of the problems in the two optimizers).

The lagrange multipliers in the string representation of the solution are now correct.

Resolves #415 

## Expected time until merged

This change is not urgent.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing

I've added a test to hs071 that verifies that the lagrange multipliers returned by SNOPT and IPOPT are correct.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
