### PR TITLE
parallel snstop

### DIFF
--- a/.github/test_real.sh
+++ b/.github/test_real.sh
@@ -11,4 +11,4 @@ cd tests
 # we have to copy over the coveragerc file to make sure it's in the
 # same directory where codecov is run
 cp ../.coveragerc .
-testflo --pre_announce --disallow_deprecations -v --coverage --coverpkg pyoptsparse $EXTRA_FLAGS
+testflo --pre_announce --disallow_deprecations -v --coverage --coverpkg pyoptsparse $EXTRA_FLAGS --timeout 60

--- a/.github/windows.yaml
+++ b/.github/windows.yaml
@@ -37,5 +37,5 @@ jobs:
 
     - script: |
         cd tests
-        testflo -n 1 .
+        testflo -n 1 --timeout 60 .
       displayName: Run tests

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -42,4 +42,4 @@ jobs:
         run: |
           conda activate pyos-build
           cd tests
-          testflo --pre_announce -v -n 1 .
+          testflo --pre_announce -v -n 1 --timeout 60 .

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -704,7 +704,7 @@ class Optimizer(BaseSolver):
 
             # Receive mode and quit if mode is -1:
             mode = self.optProb.comm.bcast(mode, root=0)
-            #mode = 0 call masterfunc2 as broadcast by root in masterfunc
+            # mode = 0 call masterfunc2 as broadcast by root in masterfunc
             if mode == 0:
                 # Receive info from shell function
                 info = self.optProb.comm.bcast(info, root=0)
@@ -716,9 +716,7 @@ class Optimizer(BaseSolver):
             elif mode == -1:
                 break
             else:
-                raise Error("Wait loop recieved code %d must be -1 or 0"%mode)
-              
-
+                raise Error("Wait loop recieved code %d must be -1 or 0" % mode)
 
     def _setInitialCacheValues(self):
         """

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -704,15 +704,21 @@ class Optimizer(BaseSolver):
 
             # Receive mode and quit if mode is -1:
             mode = self.optProb.comm.bcast(mode, root=0)
-            if mode == -1:
+            #mode = 0 call masterfunc2 as broadcast by root in masterfunc
+            if mode == 0:
+                # Receive info from shell function
+                info = self.optProb.comm.bcast(info, root=0)
+
+                # Call the generic internal function. We don't care
+                # about return values on these procs
+                self._masterFunc2(*info)
+            # mode = -1 exit wait loop
+            elif mode == -1:
                 break
+            else:
+                raise Error("Wait loop recieved code %d must be -1 or 0"%mode)
+              
 
-            # Otherwise receive info from shell function
-            info = self.optProb.comm.bcast(info, root=0)
-
-            # Call the generic internal function. We don't care
-            # about return values on these procs
-            self._masterFunc2(*info)
 
     def _setInitialCacheValues(self):
         """

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -538,7 +538,10 @@ class SNOPT(Optimizer):
 
     def _waitLoop(self):
         """Non-root processors go into this waiting loop while the
-        root proc does all the work in the optimization algorithm"""
+        root proc does all the work in the optimization algorithm
+
+        This function overwrites the namesake in the Optimizer class to add a new mode enabling parallel snstop function
+        """
 
         mode = None
         info = None
@@ -741,6 +744,7 @@ class SNOPT(Optimizer):
             if not self.storeHistory:
                 raise Error("snSTOP function handle must be used with storeHistory=True")
 
+            # Broadcasting flag to call user snstop function
             self.optProb.comm.bcast(1, root=0)
             self.optProb.comm.bcast(snstopArgs, root=0)
             iabort = snstop_handle(*snstopArgs)

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -569,9 +569,9 @@ class SNOPT(Optimizer):
                 # Get function handle and make call
                 snstop_handle = self.getOption("snSTOP function handle")
                 if snstop_handle is not None:
-                  snstop_handle(*info)
+                    snstop_handle(*info)
             else:
-                raise Error("Wait loop recieved code %d must be -1, 0, or 1 "%mode)
+                raise Error("Wait loop recieved code %d must be -1, 0, or 1 " % mode)
 
     def _userfg_wrap(self, mode, nnJac, x, fobj, gobj, fcon, gcon, nState, cu, iu, ru):
         """

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -536,6 +536,43 @@ class SNOPT(Optimizer):
         else:
             return commSol
 
+    def _waitLoop(self):
+        """Non-root processors go into this waiting loop while the
+        root proc does all the work in the optimization algorithm"""
+
+        mode = None
+        info = None
+        while True:
+            # * Note*: No checks for MPI here since this code is
+            # * only run in parallel, which assumes mpi4py is working
+
+            # Receive mode and quit if mode is -1:
+            mode = self.optProb.comm.bcast(mode, root=0)
+
+            # mode = 0 call masterfunc2 as broadcast by root in masterfunc
+            if mode == 0:
+                # Receive info from shell function
+                info = self.optProb.comm.bcast(info, root=0)
+
+                # Call the generic internal function. We don't care
+                # about return values on these procs
+                self._masterFunc2(*info)
+
+            # mode = -1 exit wait loop
+            elif mode == -1:
+                break
+
+            # mode = 1 call user snSTOP function
+            elif mode == 1:
+                # Receive function arguments from root
+                info = self.optProb.comm.bcast(info, root=0)
+                # Get function handle and make call
+                snstop_handle = self.getOption("snSTOP function handle")
+                if snstop_handle is not None:
+                  snstop_handle(*info)
+            else:
+                raise Error("Wait loop recieved code %d must be -1, 0, or 1 "%mode)
+
     def _userfg_wrap(self, mode, nnJac, x, fobj, gobj, fcon, gcon, nState, cu, iu, ru):
         """
         The snopt user function. This is what is actually called from snopt.
@@ -703,6 +740,9 @@ class SNOPT(Optimizer):
 
             if not self.storeHistory:
                 raise Error("snSTOP function handle must be used with storeHistory=True")
+
+            self.optProb.comm.bcast(1, root=0)
+            self.optProb.comm.bcast(snstopArgs, root=0)
             iabort = snstop_handle(*snstopArgs)
             # write iterDict again if anything was inserted
             if self.storeHistory and callCounter is not None:

--- a/tests/test_hs015_parallel.py
+++ b/tests/test_hs015_parallel.py
@@ -11,6 +11,7 @@ try:
     # External modules
     from mpi4py import MPI
 
+    # Setting up MPI communicators
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
     size = comm.Get_size()
@@ -38,9 +39,6 @@ class TestHS15(OptTest):
     #  Sometimes the solver converges to another local minimum
     #  at (-0.79212, -1.26243), with final objective = 360.4.
     ##
-
-    # if not HAS_MPI:
-    #     raise unittest.SkipTest("MPI not available")
 
     N_PROCS = 2  # Run case on two procs
 
@@ -106,14 +104,12 @@ class TestHS15(OptTest):
     @staticmethod
     def my_snstop(iterDict):
         """manually terminate SNOPT after 1 major iteration if"""
-        # print("Iteration", iterDict["nMajor"])
-        # print("Rank", rank)
+
         return_idx = 0
         if rank == 1 and iterDict["nMajor"] == 1:
             return_idx = comm.bcast(1, root=1)
         return_idx = comm.bcast(return_idx, root=1)
-        # comm.Barrier()
-        # print(f"return_iDX on {rank}", return_idx)
+
         return return_idx
 
     def test_optimization(self):

--- a/tests/test_hs015_parallel.py
+++ b/tests/test_hs015_parallel.py
@@ -21,11 +21,6 @@ from pyoptsparse import Optimization
 from testing_utils import OptTest
 
 
-comm = MPI.COMM_WORLD
-rank = comm.Get_rank()
-size = comm.Get_size()
-
-
 class TestHS15(OptTest):
     ## Solve test problem HS15 from the Hock & Schittkowski collection.
     #
@@ -42,6 +37,10 @@ class TestHS15(OptTest):
 
     if not HAS_MPI:
         raise unittest.SkipTest("MPI not available")
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    size = comm.Get_size()
 
     N_PROCS = 2  # Run case on two procs
 

--- a/tests/test_hs015_parallel.py
+++ b/tests/test_hs015_parallel.py
@@ -107,10 +107,11 @@ class TestHS15(OptTest):
         """manually terminate SNOPT after 1 major iteration if"""
 
         return_idx = 0
-        if rank == 1 and iterDict["nMajor"] == 1:
-            return_idx = comm.bcast(1, root=1)
-        return_idx = comm.bcast(return_idx, root=1)
-
+        if iterDict["nMajor"] == 1:
+            if comm.rank == 1:
+                comm.send(1, dest=0, tag=comm.rank)
+            elif comm.rank == 0:
+                return_idx = comm.recv(source=1)
         return return_idx
 
     def test_optimization(self):

--- a/tests/test_hs015_parallel.py
+++ b/tests/test_hs015_parallel.py
@@ -1,0 +1,142 @@
+"""Test solution of problem HS15 from the Hock & Schittkowski collection"""
+
+# Standard Python modules
+import unittest
+
+# External modules
+import numpy as np
+
+try:
+    HAS_MPI = True
+    from mpi4py import MPI
+
+    # import sabani
+except ImportError:
+    HAS_MPI = False
+
+# First party modules
+from pyoptsparse import Optimization
+
+# Local modules
+from testing_utils import OptTest
+
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+size = comm.Get_size()
+
+
+class TestHS15(OptTest):
+    ## Solve test problem HS15 from the Hock & Schittkowski collection.
+    #
+    #  min   100 (x2 - x1^2)^2 + (1 - x1)^2
+    #  s.t.  x1 x2 >= 1
+    #        x1 + x2^2 >= 0
+    #        x1 <= 0.5
+    #
+    #  The standard start point (-2, 1) usually converges to the standard
+    #  minimum at (0.5, 2.0), with final objective = 306.5.
+    #  Sometimes the solver converges to another local minimum
+    #  at (-0.79212, -1.26243), with final objective = 360.4.
+    ##
+
+    if not HAS_MPI:
+        raise unittest.SkipTest("MPI not available")
+
+    N_PROCS = 2  # Run case on two procs
+
+    name = "HS015"
+    DVs = {"xvars"}
+    cons = {"con"}
+    objs = {"obj"}
+    extras = {"extra1", "extra2"}
+    fStar = [
+        306.5,
+        360.379767,
+    ]
+    xStar = [
+        {"xvars": (0.5, 2.0)},
+        {"xvars": (-0.79212322, -1.26242985)},
+    ]
+    optOptions = {}
+
+    def objfunc(self, xdict):
+        self.nf += 1
+        x = xdict["xvars"]
+        funcs = {}
+        funcs["obj"] = [100 * (x[1] - x[0] ** 2) ** 2 + (1 - x[0]) ** 2]
+        conval = np.zeros(2, "D")
+        conval[0] = x[0] * x[1]
+        conval[1] = x[0] + x[1] ** 2
+        funcs["con"] = conval
+        # extra keys
+        funcs["extra1"] = 0.0
+        funcs["extra2"] = 1.0
+        fail = False
+        return funcs, fail
+
+    def sens(self, xdict, funcs):
+        self.ng += 1
+        x = xdict["xvars"]
+        funcsSens = {}
+        funcsSens["obj"] = {
+            "xvars": [2 * 100 * (x[1] - x[0] ** 2) * (-2 * x[0]) - 2 * (1 - x[0]), 2 * 100 * (x[1] - x[0] ** 2)]
+        }
+        funcsSens["con"] = {"xvars": [[x[1], x[0]], [1, 2 * x[1]]]}
+        fail = False
+        return funcsSens, fail
+
+    def setup_optProb(self):
+        # Optimization Object
+        self.optProb = Optimization("HS15 Constraint Problem", self.objfunc)
+
+        # Design Variables
+        lower = [-5.0, -5.0]
+        upper = [0.5, 5.0]
+        value = [-2, 1.0]
+        self.optProb.addVarGroup("xvars", 2, lower=lower, upper=upper, value=value)
+
+        # Constraints
+        lower = [1.0, 0.0]
+        upper = [None, None]
+        self.optProb.addConGroup("con", 2, lower=lower, upper=upper)
+
+        # Objective
+        self.optProb.addObj("obj")
+
+    @staticmethod
+    def my_snstop(iterDict):
+        """manually terminate SNOPT after 1 major iteration if"""
+        # print("Iteration", iterDict["nMajor"])
+        # print("Rank", rank)
+        return_idx = 0
+        if rank == 1 and iterDict["nMajor"] == 1:
+            return_idx = comm.bcast(1, root=1)
+        return_idx = comm.bcast(return_idx, root=1)
+        # comm.Barrier()
+        # print(f"return_iDX on {rank}", return_idx)
+        return return_idx
+
+    def test_optimization(self):
+        self.optName = "SNOPT"
+        self.setup_optProb()
+        sol = self.optimize()
+        # Check Solution
+        self.assert_solution_allclose(sol, 1e-12)
+        # Check informs
+        self.assert_inform_equal(sol)
+
+    def test_snopt_snstop(self):
+        self.optName = "SNOPT"
+        self.setup_optProb()
+        optOptions = {
+            "snSTOP function handle": self.my_snstop,
+        }
+        sol = self.optimize(optOptions=optOptions, storeHistory=True)
+        # Check informs
+        # we should get 70/74
+        self.assert_inform_equal(sol, optInform=74)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hs015_parallel.py
+++ b/tests/test_hs015_parallel.py
@@ -10,6 +10,10 @@ try:
     HAS_MPI = True
     # External modules
     from mpi4py import MPI
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    size = comm.Get_size()
 except ImportError:
     HAS_MPI = False
 
@@ -18,13 +22,6 @@ from pyoptsparse import Optimization
 
 # Local modules
 from testing_utils import OptTest
-
-if not HAS_MPI:
-    raise unittest.SkipTest("MPI not available")
-
-comm = MPI.COMM_WORLD
-rank = comm.Get_rank()
-size = comm.Get_size()
 
 
 class TestHS15(OptTest):
@@ -40,6 +37,9 @@ class TestHS15(OptTest):
     #  Sometimes the solver converges to another local minimum
     #  at (-0.79212, -1.26243), with final objective = 360.4.
     ##
+
+    if not HAS_MPI:
+        raise unittest.SkipTest("MPI not available")
 
     N_PROCS = 2  # Run case on two procs
 

--- a/tests/test_hs015_parallel.py
+++ b/tests/test_hs015_parallel.py
@@ -15,6 +15,7 @@ try:
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
     size = comm.Get_size()
+
 except ImportError:
     HAS_MPI = False
 

--- a/tests/test_hs015_parallel.py
+++ b/tests/test_hs015_parallel.py
@@ -13,12 +13,18 @@ try:
     # import sabani
 except ImportError:
     HAS_MPI = False
+    raise unittest.SkipTest("MPI not available")
 
 # First party modules
 from pyoptsparse import Optimization
 
 # Local modules
 from testing_utils import OptTest
+
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+size = comm.Get_size()
 
 
 class TestHS15(OptTest):
@@ -34,13 +40,6 @@ class TestHS15(OptTest):
     #  Sometimes the solver converges to another local minimum
     #  at (-0.79212, -1.26243), with final objective = 360.4.
     ##
-
-    if not HAS_MPI:
-        raise unittest.SkipTest("MPI not available")
-
-    comm = MPI.COMM_WORLD
-    rank = comm.Get_rank()
-    size = comm.Get_size()
 
     N_PROCS = 2  # Run case on two procs
 

--- a/tests/test_hs015_parallel.py
+++ b/tests/test_hs015_parallel.py
@@ -10,17 +10,17 @@ try:
     HAS_MPI = True
     # External modules
     from mpi4py import MPI
-
-    # import sabani
 except ImportError:
     HAS_MPI = False
-    raise unittest.SkipTest("MPI not available")
 
 # First party modules
 from pyoptsparse import Optimization
 
 # Local modules
 from testing_utils import OptTest
+
+if not HAS_MPI:
+    raise unittest.SkipTest("MPI not available")
 
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()

--- a/tests/test_hs015_parallel.py
+++ b/tests/test_hs015_parallel.py
@@ -8,6 +8,7 @@ import numpy as np
 
 try:
     HAS_MPI = True
+    # External modules
     from mpi4py import MPI
 
     # import sabani
@@ -20,7 +21,6 @@ from pyoptsparse import Optimization
 
 # Local modules
 from testing_utils import OptTest
-
 
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()

--- a/tests/test_hs015_parallel.py
+++ b/tests/test_hs015_parallel.py
@@ -24,6 +24,7 @@ from pyoptsparse import Optimization
 from testing_utils import OptTest
 
 
+@unittest.skipIf(not HAS_MPI, "MPI not available")
 class TestHS15(OptTest):
     ## Solve test problem HS15 from the Hock & Schittkowski collection.
     #
@@ -38,8 +39,8 @@ class TestHS15(OptTest):
     #  at (-0.79212, -1.26243), with final objective = 360.4.
     ##
 
-    if not HAS_MPI:
-        raise unittest.SkipTest("MPI not available")
+    # if not HAS_MPI:
+    #     raise unittest.SkipTest("MPI not available")
 
     N_PROCS = 2  # Run case on two procs
 


### PR DESCRIPTION
## Purpose
<!--
Parallelize user defined snSTOP function so all mpi processes call it instead of just the root.
-->

## Expected time until merged
<!--
1  month
-->

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
Any script that runs in parallel check pass snSTOP handle and check if all mpi ranks call the function and have the same input arguments.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
