### PR TITLE
Fix windows build for numpy 2.0

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -6,7 +6,6 @@ dependencies:
   - swig
   - meson >=1.3.2
   - compilers
-  - flang
   - pkg-config
   - pip
   - setuptools

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -34,7 +34,6 @@ jobs:
         shell: cmd /C CALL {0}
         run: |
           call conda activate pyos-build
-          call conda list
           set IPOPT_DIR=%CONDA_PREFIX%\Library
 
           # We want to use the clang linker `ld-lld.exe`

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -34,10 +34,17 @@ jobs:
         shell: cmd /C CALL {0}
         run: |
           call conda activate pyos-build
+          call conda list
           set IPOPT_DIR=%CONDA_PREFIX%\Library
-          set CC=cl
-          set FC=flang
-          set CC_LD=link
+
+          # We want to use the clang linker `ld-lld.exe`
+          # The conda-forge clang packages set the LD environment variable and LDFLAGS for that linker.
+          # But meson doesn't respect the LD environment variable - so set `<compiler entry>_LD`
+          # https://mesonbuild.com/howtox.html#set-linker
+          set CC_LD=%LD%
+          set CXX_LD=%LD%
+          set FC_LD=%LD%
+
           python -m build -n -x .
           pip install --no-deps --no-index --find-links dist pyoptsparse
       - name: Install runtime numpy ${{ matrix.numpy_version }}


### PR DESCRIPTION
Fix the window build on the in-development numpy 2.0 branch.

There were a few problems:
1. `set FC=flang` is not necessary - this env var is set by activation scripts provided by the conda-forge `flang_impl_win-64` package. The correct compiler variable is `FC=flang-new` anyway.
2. Similarly, `set CC=` is not necessary, as it is set by the `vc` "activation" package from conda-forge. It looks like this variable was previously set to `clang`. On conda-forge we will most likely build with MSVC, so might as well just leave it as that for now.
3. We need to link with the LLVM linker `ld-lld`, not the MSVC linker `link`. The conda-forge clang/flang packages set the `LD` variable to `ld-lld`, but _Meson_ doesn't respect the `LD` variable. Therefore, we need to re-export these to variables that Meson does understand - `CC_LD` and `FC_LD`. See https://mesonbuild.com/howtox.html#set-linker for details.

Note that the target of this PR is the in-development `support-numpy2` branch.