### PR TITLE
Update removed C API in py313

### DIFF
--- a/pyoptsparse/pyNSGA2/source/swig/nsga2.i
+++ b/pyoptsparse/pyNSGA2/source/swig/nsga2.i
@@ -93,7 +93,7 @@ void nsga2func (int nreal, int nbin, int nobj, int ncon, double *xreal, double *
 	{
 		Py_XINCREF(py_fobjcon);
 		Py_XINCREF(arglist);
-		result = PyEval_CallObject(py_fobjcon, arglist);
+		result = PyObject_CallObject(py_fobjcon, arglist);
 		Py_XINCREF(result);
 		Py_XDECREF(py_fobjcon);
 		Py_XDECREF(arglist);


### PR DESCRIPTION
## Purpose
Discovered in conda-forge/pyoptsparse-feedstock#60, the same patch was applied there to successfully build py313.

## Expected time until merged
A few days

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
None

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
