### PR TITLE
Remove invalid escape sequence from docstring

### DIFF
--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -976,7 +976,7 @@ def OPT(optName, *args, **kwargs):
        Either a string identifying the optimizer to create, e.g. "SNOPT", or
        an enum accessed via ``pyoptsparse.Optimizers``, e.g. ``Optimizers.SNOPT``.
 
-    \*args, \*\*kwargs : varies
+    *args, **kwargs : varies
        Passed to optimizer creation.
 
     Returns


### PR DESCRIPTION
## Purpose
This PR removes an invalid escape sequence from one docstring, and so fixes the warning:

```
> python
Python 3.13.3 | packaged by conda-forge | (main, Apr 14 2025, 20:44:03) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pyoptsparse import pySNOPT
/home/dingraha/projects/aviary_propeller/ved/pyoptsparse/pyoptsparse/pyOpt_optimizer.py:979: SyntaxWarning: invalid escape sequence '\*'
  \*args, \*\*kwargs : varies
>>>
```

Here is a stackoverflow post explaining the issue: https://stackoverflow.com/questions/52335970/how-to-fix-syntaxwarning-invalid-escape-sequence-in-python, and here are the valid escape sequences in Python: https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences. You'll see that `\*` is not listed.

## Expected time until merged
Not urgent.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
No testing needed, but I did run the tests in `tests` and they seemed OK (but I don't have all the optimizers pyoptsparse supports so it's tough to tell).

## Checklist


- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
