### PR TITLE
Change minimum numpy version in pyproject to match setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "meson>=0.60.0", "ninja", "numpy>=2.0", "swig"]
+requires = ["setuptools>=42", "meson>=0.60.0", "ninja", "numpy", "swig"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "meson>=0.60.0", "ninja", "numpy", "swig"]
+requires = ["setuptools>=42", "meson>=0.60.0", "ninja", "numpy>=1.21", "swig"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Purpose
`setup.py` specifies "numpy>1.21", but `pyproject.toml` restricts "numpy>2". It's possible this was an oversight, since pyoptsparse does not strictly require numpy 2, and forcing this version breaks compatibility with any other packages that don't support numpy 2 yet. I've set the required numpy version in `pyproject.toml` to match ">1.2.1"

This should hopefully cover everyone satisfactorily - you will get numpy>2 by default (installing pyoptsparse first), but if your environment already has a numpy 1.X version then this change should allow you to continue using it without forcing an upgrade.

## Expected time until merged
1 week

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [x] Other (please describe)

Allows for use of latest pyoptsparse with environments that require numpy<2 (so not a "bug" with pyoptsparse itself)

## Testing
In fresh Python/conda env, install numpy=1.26
Install pyoptsparse (try with both pip and conda installs)
- List of new packages to be installed should NOT include numpy>=2
`conda list` and `pip list` should still point to numpy=1.26
Activating Python and running:
```
import numpy as np
foo = np.Inf
```
should NOT return an error - this function will raise an error if numpy>=2 was still added to the environment (I've seen conda sometimes not show in `conda list` that a package version was updated)

## Checklist
- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [x] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation

As far as I'm aware there is nowhere in the documentation that talks about using numpy>2 so no changes required