### PR TITLE
 Fix SolutionInform dict access

### DIFF
--- a/pyoptsparse/__init__.py
+++ b/pyoptsparse/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.14.1.post1"
+__version__ = "2.14.2"
 
 from .pyOpt_history import History
 from .pyOpt_variable import Variable

--- a/pyoptsparse/__init__.py
+++ b/pyoptsparse/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.14.1"
+__version__ = "2.14.1.post1"
 
 from .pyOpt_history import History
 from .pyOpt_variable import Variable

--- a/pyoptsparse/pyOpt_solution.py
+++ b/pyoptsparse/pyOpt_solution.py
@@ -1,6 +1,6 @@
 # Standard Python modules
 import copy
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Optional
 
 # External modules
@@ -22,6 +22,10 @@ class SolutionInform:
     @classmethod
     def from_informs(cls, informs: dict[int, str], value: int):
         return cls(value=value, message=informs[value])
+
+    def __getitem__(self, key):
+        d = asdict(self)
+        return d[key]
 
 
 class Solution(Optimization):

--- a/pyoptsparse/pyOpt_solution.py
+++ b/pyoptsparse/pyOpt_solution.py
@@ -25,6 +25,8 @@ class SolutionInform:
 
     def __getitem__(self, key):
         d = asdict(self)
+        if key == "text":
+            return d["message"]
         return d[key]
 
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5,6 +5,7 @@ import unittest
 
 # First party modules
 from pyoptsparse import Optimizers, list_optimizers
+from pyoptsparse.pyOpt_solution import SolutionInform
 from pyoptsparse.pyOpt_utils import try_import_compiled_module_from_path
 
 # we have to unset this environment variable because otherwise
@@ -36,3 +37,12 @@ class TestListOpt(unittest.TestCase):
         self.assertIn(Optimizers.PSQP, all_opt)
         self.assertIn(Optimizers.ALPSO, all_opt)
         self.assertIn(Optimizers.NSGA2, all_opt)
+
+
+class TestSolInform(unittest.TestCase):
+    def test_sol_inform_key_access(self):
+        sol = SolutionInform(value=1, message="test message")
+        assert sol.value == 1
+        assert sol["value"] == 1
+        assert sol.message == "test message"
+        assert sol["text"] == "test message"


### PR DESCRIPTION
## Purpose
Created from #450.

Realized that we effectively broke sol_inform in #437 because we were previously using a dict. This is now fixed by implementing `__getitem__`, and I think we should just make a patch release ASAP, this oversight is probably going to break pretty much everyone's code...

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
