### PR TITLE
Slow down TP109 function evaluation to fix SNOPT testing issue

### DIFF
--- a/tests/test_tp109.py
+++ b/tests/test_tp109.py
@@ -30,6 +30,7 @@ Test uses Schittkowski's TP109 constraint problem.
 
 # Standard Python modules
 import unittest
+import time
 
 # External modules
 import numpy as np
@@ -124,6 +125,11 @@ class TestTP109(OptTest):
         else:
             funcs["con"] = fcon[0:10]
         fail = False
+
+        # Depending on your compiler/CPU, SNOPT may only be measuring CPU time to the nearest millisecond, in these
+        # cases, SNOPT can sometimes solve the problem before it registers that any time has elapsed, which causes
+        # `test_snopt_informs` to fail. To fix this we simply slow down the function evaluation very slightly.
+        time.sleep(1e-3)
 
         return funcs, fail
 

--- a/tests/test_tp109.py
+++ b/tests/test_tp109.py
@@ -62,6 +62,7 @@ class TestTP109(OptTest):
             368.4881990875219,
         )
     }
+    slowDownFunc = False
 
     def objfunc(self, xdict):
         x = xdict["xvars"]
@@ -129,7 +130,8 @@ class TestTP109(OptTest):
         # Depending on your compiler/CPU, SNOPT may only be measuring CPU time to the nearest millisecond, in these
         # cases, SNOPT can sometimes solve the problem before it registers that any time has elapsed, which causes
         # `test_snopt_informs` to fail. To fix this we simply slow down the function evaluation very slightly.
-        time.sleep(1e-3)
+        if self.slowDownFunc:
+            time.sleep(1e-3)
 
         return funcs, fail
 
@@ -181,6 +183,7 @@ class TestTP109(OptTest):
 
     def test_snopt_informs(self):
         self.optName = "SNOPT"
+        self.slowDownFunc = True
         self.setup_optProb()
         sol = self.optimize(optOptions={"Time Limit": 1e-15})
         self.assert_inform_equal(sol, 34)

--- a/tests/test_tp109.py
+++ b/tests/test_tp109.py
@@ -29,8 +29,8 @@ Test uses Schittkowski's TP109 constraint problem.
 """
 
 # Standard Python modules
-import unittest
 import time
+import unittest
 
 # External modules
 import numpy as np


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
Fixes #477, where SNOPT was occasionally succesfully solving the TP109 problem despite being given a time limit of 1e-15 seconds.

SNOPT uses the `system_clock` function to measure the elapsed time at each function evaluation. Depending on the integer types passed to this function, [the resulting time measurement may only have millisecond precision](https://gcc.gnu.org/onlinedocs/gfortran/SYSTEM_005fCLOCK.html). I therefore believe the issue is that when function evaluations are on the order of <=1ms and the default fortran integer is 32 bit (kind=4), SNOPT will often register function evaluations as taking zero time, thus messing up the enforcement of the time limit.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
Soon plz

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
