### PR TITLE
Fix mutable default argument in optimizer `__init__`s

### DIFF
--- a/pyoptsparse/pyALPSO/pyALPSO.py
+++ b/pyoptsparse/pyALPSO/pyALPSO.py
@@ -26,7 +26,9 @@ class ALPSO(Optimizer):
     - pll_type -> STR: ALPSO Parallel Implementation (None, SPM- Static, DPM- Dynamic, POA-Parallel Analysis), *Default* = None
     """
 
-    def __init__(self, options={}):
+    def __init__(self, options=None):
+        if options is None:
+            options = {}
         self.alpso = alpso
 
         category = "Global Optimizer"

--- a/pyoptsparse/pyCONMIN/pyCONMIN.py
+++ b/pyoptsparse/pyCONMIN/pyCONMIN.py
@@ -25,7 +25,9 @@ class CONMIN(Optimizer):
     CONMIN Optimizer Class - Inherited from Optimizer Abstract Class
     """
 
-    def __init__(self, raiseError=True, options={}):
+    def __init__(self, raiseError=True, options=None):
+        if options is None:
+            options = {}
         name = "CONMIN"
         category = "Local Optimizer"
         defOpts = self._getDefaultOptions()

--- a/pyoptsparse/pyIPOPT/pyIPOPT.py
+++ b/pyoptsparse/pyIPOPT/pyIPOPT.py
@@ -24,11 +24,12 @@ class IPOPT(Optimizer):
     IPOPT Optimizer Class - Inherited from Optimizer Abstract Class
     """
 
-    def __init__(self, raiseError=True, options={}):
+    def __init__(self, raiseError=True, options=None):
         """
         IPOPT Optimizer Class Initialization
         """
-
+        if options is None:
+            options = {}
         name = "IPOPT"
         category = "Local Optimizer"
         defOpts = self._getDefaultOptions()

--- a/pyoptsparse/pyNLPQLP/pyNLPQLP.py
+++ b/pyoptsparse/pyNLPQLP/pyNLPQLP.py
@@ -26,7 +26,9 @@ class NLPQLP(Optimizer):
     NLPQL Optimizer Class - Inherited from Optimizer Abstract Class
     """
 
-    def __init__(self, raiseError=True, options={}):
+    def __init__(self, raiseError=True, options=None):
+        if options is None:
+            options = {}
         name = "NLPQLP"
         category = "Local Optimizer"
         defOpts = self._getDefaultOptions()

--- a/pyoptsparse/pyNSGA2/pyNSGA2.py
+++ b/pyoptsparse/pyNSGA2/pyNSGA2.py
@@ -25,7 +25,9 @@ class NSGA2(Optimizer):
     NSGA2 Optimizer Class - Inherited from Optimizer Abstract Class
     """
 
-    def __init__(self, raiseError=True, options={}):
+    def __init__(self, raiseError=True, options=None):
+        if options is None:
+            options = {}
         name = "NSGA-II"
         category = "Global Optimizer"
         defOpts = self._getDefaultOptions()

--- a/pyoptsparse/pyOpt_optimizer.py
+++ b/pyoptsparse/pyOpt_optimizer.py
@@ -31,9 +31,9 @@ class Optimizer(BaseSolver):
         self,
         name: str,
         category: str,
-        defaultOptions: Dict[str, Any] = {},
-        informs: Dict[int, str] = {},
-        options: Dict[str, Any] = {},
+        defaultOptions: Optional[Dict[str, Any]] = None,
+        informs: Optional[Dict[int, str]] = None,
+        options: Optional[Dict[str, Any]] = None,
         checkDefaultOptions: bool = True,
         caseSensitiveOptions: bool = True,
         version: Optional[str] = None,
@@ -53,6 +53,12 @@ class Optimizer(BaseSolver):
         informs : dict
             Dictionary of the inform codes
         """
+        if defaultOptions is None:
+            defaultOptions = {}
+        if informs is None:
+            informs = {}
+        if options is None:
+            options = {}
         super().__init__(
             name,
             category,

--- a/pyoptsparse/pyPSQP/pyPSQP.py
+++ b/pyoptsparse/pyPSQP/pyPSQP.py
@@ -25,7 +25,9 @@ class PSQP(Optimizer):
     PSQP Optimizer Class - Inherited from Optimizer Abstract Class
     """
 
-    def __init__(self, raiseError=True, options={}):
+    def __init__(self, raiseError=True, options=None):
+        if options is None:
+            options = {}
         name = "PSQP"
         category = "Local Optimizer"
         defOpts = self._getDefaultOptions()

--- a/pyoptsparse/pyParOpt/ParOpt.py
+++ b/pyoptsparse/pyParOpt/ParOpt.py
@@ -8,7 +8,9 @@ except ImportError as e:
 
     def make_cls(e):
         class ParOpt(Optimizer):
-            def __init__(self, raiseError=True, options={}):
+            def __init__(self, raiseError=True, options=None):
+                if options is None:
+                    options = {}
                 name = "ParOpt"
                 category = "Local Optimizer"
                 self.defOpts = {}

--- a/pyoptsparse/pySLSQP/pySLSQP.py
+++ b/pyoptsparse/pySLSQP/pySLSQP.py
@@ -27,7 +27,9 @@ class SLSQP(Optimizer):
     SLSQP Optimizer Class - Inherited from Optimizer Abstract Class
     """
 
-    def __init__(self, raiseError=True, options={}):
+    def __init__(self, raiseError=True, options=None):
+        if options is None:
+            options = {}
         name = "SLSQP"
         category = "Local Optimizer"
         defOpts = self._getDefaultOptions()

--- a/pyoptsparse/pySNOPT/pySNOPT.py
+++ b/pyoptsparse/pySNOPT/pySNOPT.py
@@ -43,7 +43,9 @@ class SNOPT(Optimizer):
     SNOPT Optimizer Class
     """
 
-    def __init__(self, raiseError=True, options: Dict = {}):
+    def __init__(self, raiseError=True, options: Optional[Dict] = None):
+        if options is None:
+            options = {}
         name = "SNOPT"
         category = "Local Optimizer"
         defOpts = self._getDefaultOptions()


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
Replaces all uses of an empty dictionary as a default argument ([which is bad](https://docs.astral.sh/ruff/rules/mutable-argument-default/)) with `None` .

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
